### PR TITLE
fix: use semantic release to release binaries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
             - image: circleci/node:latest
         steps:
             - checkout
-            - run: npm install pkg --save-dev
+            - run: npm install semantic-release @semantic-release/exec pkg --save-dev
             - run: npm install
             - run: npm test
             - snyk/scan:
@@ -16,11 +16,11 @@ jobs:
                 token-variable: SNYK_TOKEN
             - run: npx tsc
             - run: npx semantic-release
-            - run: npm run pkg-binaries && cp package.json dist/
-            - persist_to_workspace:
-                root: .
-                paths:
-                  - dist/*
+            # - run: npm run pkg-binaries && cp package.json dist/
+            # - persist_to_workspace:
+            #     root: .
+            #     paths:
+            #       - dist/*
     build-test:
         docker:
             - image: circleci/node:latest
@@ -42,26 +42,26 @@ jobs:
             - run: npm test
             - run: npx tsc
 
-    publish-github-release:
-        docker:
-          - image: gcr.io/snyk-technical-services/cicd-github
-            auth:
-              username: _json_key
-              password: $GCLOUD_GCR_SNYK_TS_READER
-        steps:
-          - checkout
-          - attach_workspace:
-              at: .
-          - run:
-              name: "Publish Release on GitHub"
-              command: |    
-                # VERSIONJUMP=$(git log --oneline -1 --pretty=%B | cat | grep -E 'minor|major|patch' | awk -F ':' '{print $1}')   
-                # VERSION=$(/workdir/nextver.sh "$VERSIONJUMP")
-                VERSION=$(cat /root/project/dist/package.json | grep version | awk {'print $2'} | sed 's/"//g' | sed 's/,//g')
-                cd /root/project/dist/binaries
-                sha256sum snyk-delta-linux > snyk-delta-linux.sha256 && sha256sum snyk-delta-macos > snyk-delta-macos.sha256 && sha256sum snyk-delta-win.exe > snyk-delta-win.exe.sha256
-                cd -
-                ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} dist/binaries
+    # publish-github-release:
+    #     docker:
+    #       - image: gcr.io/snyk-technical-services/cicd-github
+    #         auth:
+    #           username: _json_key
+    #           password: $GCLOUD_GCR_SNYK_TS_READER
+    #     steps:
+    #       - checkout
+    #       - attach_workspace:
+    #           at: .
+    #       - run:
+    #           name: "Publish Release on GitHub"
+    #           command: |    
+    #             # VERSIONJUMP=$(git log --oneline -1 --pretty=%B | cat | grep -E 'minor|major|patch' | awk -F ':' '{print $1}')   
+    #             # VERSION=$(/workdir/nextver.sh "$VERSIONJUMP")
+    #             VERSION=$(cat /root/project/dist/package.json | grep version | awk {'print $2'} | sed 's/"//g' | sed 's/,//g')
+    #             cd /root/project/dist/binaries
+    #             sha256sum snyk-delta-linux > snyk-delta-linux.sha256 && sha256sum snyk-delta-macos > snyk-delta-macos.sha256 && sha256sum snyk-delta-win.exe > snyk-delta-win.exe.sha256
+    #             cd -
+    #             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} ${VERSION} dist/binaries
 workflows:
     version: 2.1
     nightly:
@@ -83,14 +83,14 @@ workflows:
                     branches:
                         only:
                             - master
-            - publish-github-release:
-                context: SNYK
-                requires:
-                    - build-test-monitor
-                filters:
-                    branches:
-                      only:
-                        - master
+            # - publish-github-release:
+            #     context: SNYK
+            #     requires:
+            #         - build-test-monitor
+            #     filters:
+            #         branches:
+            #           only:
+            #             - master
     build-test:
         jobs:
             - build-test:

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,63 @@
+{
+  "prepare": [
+    "@semantic-release/npm",
+    {
+      "//": "adds a file to identify a build as a standalone binary",
+      "path": "@semantic-release/exec",
+      "cmd": "echo '' > dist/STANDALONE"
+    },
+    {
+      "//": "build the alpine, macos, linux and windows binaries",
+      "path": "@semantic-release/exec",
+      "cmd": "run pkg . -t node12-linux-x64,node12-macos-x64,node12-win-x64"
+    },
+    {
+      "//": "shasum all binaries",
+      "path": "@semantic-release/exec",
+      "cmd": "sha256sum snyk-linux > snyk-linux.sha256 && sha256sum snyk-macos > snyk-macos.sha256 && sha256sum snyk-win.exe > snyk-win.exe.sha256"
+    },
+    {
+      "//": "removes the file we use to identify a build as a standalone binary",
+      "path": "@semantic-release/exec",
+      "cmd": "rm dist/STANDALONE"
+    }
+  ],
+  "publish": [
+    "@semantic-release/npm",
+    {
+      "path": "@semantic-release/github",
+      "assets": [
+        {
+          "path": "./snyk-linux",
+          "name": "snyk-linux",
+          "label": "snyk-linux"
+        },
+        {
+          "path": "./snyk-linux.sha256",
+          "name": "snyk-linux.sha256",
+          "label": "snyk-linux.sha256"
+        },
+        {
+          "path": "./snyk-macos",
+          "name": "snyk-macos",
+          "label": "snyk-macos"
+        },
+        {
+          "path": "./snyk-macos.sha256",
+          "name": "snyk-macos.sha256",
+          "label": "snyk-macos.sha256"
+        },
+        {
+          "path": "./snyk-win.exe",
+          "name": "snyk-win.exe",
+          "label": "snyk-win.exe"
+        },
+        {
+          "path": "./snyk-win.exe.sha256",
+          "name": "snyk-win.exe.sha256",
+          "label": "snyk-win.exe.sha256"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

use semantic release to release binaries to be more consistent across output types (module vs binary)

