### PR TITLE
fix: use exclusively .releaserc for sem release

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -59,5 +59,6 @@
         }
       ]
     }
-  ]
+  ],
+  "branches": ["master"]
 }

--- a/package.json
+++ b/package.json
@@ -79,8 +79,5 @@
       "dist/**/*.js"
     ]
   },
-  "release": {
-    "branches": ["master"]
-  },
   "snyk": true
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

use exclusively .releaserc for sem release
