### PR TITLE
fix: Fix package.json moving around during dist

### DIFF
--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -1,6 +1,8 @@
 import * as debugModule from 'debug'
 const yargs = require('yargs');
-const pkgJSON = require(require('app-root-path').resolve('package.json'))
+import * as fs from 'fs'
+import * as path from 'path'
+//const pkgJSON = require(require('app-root-path').resolve('package.json'))
 import * as chalk from 'chalk';
 import { BadInputError } from '../customErrors/inputError';
 
@@ -15,6 +17,10 @@ const getDebugModule = () => {
 }
 
 const init = () => {
+  
+    const pkgJSONPath = fs.existsSync(__dirname+'/../../../package.json')? __dirname+'/../../../package.json' : path.dirname(path.dirname(__dirname))+'/package.json'
+    const pkgJSON = JSON.parse(fs.readFileSync(pkgJSONPath).toString())
+
     const argv = yargs
     .usage('============================')
     .usage('2 modes of operations - Inline or Standalone')


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Since I couldn't get the tsconfig to bring the package.json without somehow breaking the npm packaging, I decided to take a different approach and targeting down the location of package.json across deliveries. Not the cleanest but can't figure out for the life of me why using resolveJsonModule in tsconfig somehow breaks everything....
