### PR TITLE
fix: Add instruction to use globally

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import 'source-map-support/register';
 import * as snyk from './snyk/snyk';
 import handleError from './error';


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

add #!/usr/bin/env node to index to make it work when npm installed globally
