### PR TITLE
fix: call initial function if no parent module

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -114,7 +114,7 @@ const getDelta = async(snykTestOutput: string = '') => {
 
 }
 
-if(process.env.NODE_ENV != 'test'){
+if(!module.parent){
   getDelta()
 }
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes the default exported function being called when loaded as module.

