### PR TITLE
feat: Add breakBuild flag for module usage

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -17,7 +17,7 @@ Snyk Tech Prevent Tool
 `
 
 
-const getDelta = async(snykTestOutput: string = '') => {
+const getDelta = async(snykTestOutput: string = '', breakBuild: boolean = true) => {
    const argv = utils.init()
    const debug = utils.getDebugModule()
    const mode = argv.currentProject || argv.currentOrg ? "standalone" : "inline"
@@ -109,6 +109,9 @@ const getDelta = async(snykTestOutput: string = '') => {
     handleError(err)
     process.exitCode = 2
   } finally {
+    if(!breakBuild) {
+      process.exitCode = 0
+    }
     process.exit(process.exitCode)
   }
 


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Allow to not return non 0 in case we want to function in non breaking mode in npm module usage.
