### PR TITLE
chore: Add SNYK context to nightly job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ workflows:
                   only:
                     - master
         jobs:
-            - build-test-monitor
+            - build-test-monitor:
+                context: SNYK
 
     build-test-monitor:
         jobs:


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Makes sure the nightly job doesn't fail because it's missing the snyk token
