### PR TITLE
chore: release fix to circleci nightly job missing context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,8 @@ workflows:
                   only:
                     - master
         jobs:
-            - build-test-monitor
+            - build-test-monitor:
+                context: SNYK
 
     build-test-monitor:
         jobs:


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Just add context: SNYK to nightly job.
