### PR TITLE
fix: Handle targetfile proj name for json output proj matching

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -49,9 +49,12 @@ const getDelta = async(snykTestOutput: string = '', debugMode = false) => {
       
       snykTestJsonDependencies = inputData.length > 1 ? inputData[0] : null
       snykTestJsonResults = inputData.length > 1 ? inputData[1]: inputData[0]
+      const projectNameFromJson = snykTestJsonResults.targetFile? 
+                                  `${snykTestJsonResults.projectName}:${snykTestJsonResults.targetFile}` :
+                                  `${snykTestJsonResults.projectName}`
 
       baselineOrg = baselineOrg? baselineOrg : snykTestJsonResults.org
-      baselineProject = baselineProject? baselineProject : snykTestJsonResults.projectName
+      baselineProject = baselineProject? baselineProject : projectNameFromJson
 
       if(argv.baselineProject && !isUUID.anyNonNil(baselineProject)){
         throw new BadInputError("Project ID must be valid UUID")

--- a/test/fixtures/apiResponses/test-gomod.json
+++ b/test/fixtures/apiResponses/test-gomod.json
@@ -1,0 +1,10 @@
+{
+    "ok": true,
+    "deprecated": "This endpoint is deprecated, please use list-all-aggregated-issues endpoint instead.\nhttps://snyk.docs.apiary.io/#reference/projects/aggregated-project-issues/list-all-aggregated-issues",
+    "issues": {
+      "vulnerabilities": [],
+      "licenses": []
+    },
+    "dependencyCount": 8,
+    "packageManager": "gomodules"
+  }

--- a/test/fixtures/apiResponsesForProjects/list-all-projects-org-playground.json
+++ b/test/fixtures/apiResponsesForProjects/list-all-projects-org-playground.json
@@ -724,6 +724,34 @@
           "email": "aarlaud@hotmail.com"
         },
         "branch": null
+      },
+      {
+        "name": "github.com/snyk-tech-services/ira-tickets-for-new-vulns:go.mod",
+        "id": "09235fa4-c241-42c6-8c63-c053bd272786",
+        "created": "2020-03-20T15:26:50.830Z",
+        "origin": "cli",
+        "type": "gomodules",
+        "readOnly": false,
+        "testFrequency": "daily",
+        "totalDependencies": 8,
+        "issueCountsBySeverity": {
+          "low": 0,
+          "high": 0,
+          "medium": 0
+        },
+        "remoteRepoUrl": "http://github.com/snyk-tech-services/jira-tickets-for-new-vulns.git",
+        "imageTag": "0.0.0",
+        "lastTestedDate": "2020-07-08T00:11:24.801Z",
+        "browseUrl": "https://app.snyk.io/org/customer-facing-tools/project/09235fa4-c241-42c6-8c63-c053bd272786",
+        "owner": null,
+        "importingUser": {
+          "id": "9dd0a178-16a0-4376-a13d-fef51515d0e9",
+          "name": "CircleCI pipelines",
+          "username": "CircleCI pipelines",
+          "email": null
+        },
+        "tags": [],
+        "branch": null
       }
     ]
   }

--- a/test/fixtures/snykTestsOutputs/test-gomod.json
+++ b/test/fixtures/snykTestsOutputs/test-gomod.json
@@ -1,0 +1,103 @@
+{
+    "vulnerabilities": [],
+    "ok": true,
+    "dependencyCount": 8,
+    "org": "playground",
+    "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.16.0\nignore: {}\npatch: {}\n",
+    "isPrivate": true,
+    "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {
+        "AGPL-1.0": {
+          "licenseType": "AGPL-1.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "AGPL-3.0": {
+          "licenseType": "AGPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "Artistic-1.0": {
+          "licenseType": "Artistic-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "Artistic-2.0": {
+          "licenseType": "Artistic-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CDDL-1.0": {
+          "licenseType": "CDDL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "CPOL-1.02": {
+          "licenseType": "CPOL-1.02",
+          "severity": "high",
+          "instructions": ""
+        },
+        "EPL-1.0": {
+          "licenseType": "EPL-1.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "GPL-2.0": {
+          "licenseType": "GPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "GPL-3.0": {
+          "licenseType": "GPL-3.0",
+          "severity": "high",
+          "instructions": ""
+        },
+        "LGPL-2.0": {
+          "licenseType": "LGPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-2.1": {
+          "licenseType": "LGPL-2.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "LGPL-3.0": {
+          "licenseType": "LGPL-3.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-1.1": {
+          "licenseType": "MPL-1.1",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MPL-2.0": {
+          "licenseType": "MPL-2.0",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "MS-RL": {
+          "licenseType": "MS-RL",
+          "severity": "medium",
+          "instructions": ""
+        },
+        "SimPL-2.0": {
+          "licenseType": "SimPL-2.0",
+          "severity": "high",
+          "instructions": ""
+        }
+      }
+    },
+    "packageManager": "gomodules",
+    "ignoreSettings": null,
+    "summary": "No known vulnerabilities",
+    "filesystemPolicy": false,
+    "uniqueCount": 0,
+    "targetFile": "go.mod",
+    "projectName": "github.com/snyk-tech-services/ira-tickets-for-new-vulns",
+    "displayTargetFile": "go.mod",
+    "path": "/home/antoine/Documents/SnykTSDev/jira-tickets-for-new-vulns/snyk-tech-services/ira-tickets-for-new-vulns"
+  }
+  

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -46,6 +46,10 @@ beforeEach(() => {
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/test-goof.json',
           );
+        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/test-gomod.json',
+          );
         case '/api/v1/org/playground/projects':
           return fs.readFileSync(
             fixturesFolderPath +
@@ -114,5 +118,23 @@ describe('Test End 2 End - Inline mode', () => {
     //expect(mockExit).toHaveBeenCalledWith(1);
     // => When testing, loaded as module therefore returning code === process.exitCode
     expect(result).toEqual(1);
+  });
+
+  it('Test Inline mode - no new issue go modules project', async () => {
+    setTimeout(() => {
+      stdinMock.send(
+        fs
+          .readFileSync(fixturesFolderPath + 'snykTestsOutputs/test-gomod.json')
+          .toString(),
+      );
+      stdinMock.send(null);
+    }, 100);
+
+    const result = await getDelta();
+    expect(consoleOutput).toContain('No new issues found !');
+
+    //expect(mockExit).toHaveBeenCalledWith(0);
+    // => When testing, loaded as module therefore returning code === process.exitCode
+    expect(result).toEqual(0);
   });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Handles cases when project name contains the targetfile appended after ':'. Typical for SCM projects, ecosystem specific for CLI.

