### PR TITLE
fix: check if vulnerable path is new and pass if not

### DIFF
--- a/src/lib/snyk/issues.ts
+++ b/src/lib/snyk/issues.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash'
 import * as chalk from 'chalk'
 import * as terminalLink from 'terminal-link'
 import * as snykTypes from './types'
-
+import { isVulnerablePathNew } from '../utils/issuesUtils'
 enum severityThresholds {
   "low" = 1,
   "medium" = 2,
@@ -30,7 +30,8 @@ const getNewVulns = (snykProject: any, snykTestJsonResults: any, mode: string): 
         if(mode == 'inline') {
           vulnFromArray = vulnFromArray.slice(1,vulnFromArray.length)
         }
-        return (monitoredVuln.id == vuln.id) && _.isEqual(monitoredVuln.from, vulnFromArray)
+
+        return (monitoredVuln.id == vuln.id) && !isVulnerablePathNew(monitoredVuln.from, vulnFromArray)
 
       })
     })

--- a/src/lib/utils/issuesUtils.ts
+++ b/src/lib/utils/issuesUtils.ts
@@ -1,0 +1,12 @@
+import * as _ from 'lodash'
+
+const isVulnerablePathNew = (monitoredSnapshotPathArray: Array<string>, currentSnapshotPathArray: Array<string> ): boolean => {
+    const versionPatternRegex = /@[a-zA-Z0-9-_\.]+$/
+    return !(_.isEqual(monitoredSnapshotPathArray, currentSnapshotPathArray) || monitoredSnapshotPathArray.every((path, index) => {
+        return path.split(versionPatternRegex)[0] == currentSnapshotPathArray[index].split(versionPatternRegex)[0]
+    }))
+}
+
+export {
+    isVulnerablePathNew
+}

--- a/test/fixtures/apiResponses/java-goof.json
+++ b/test/fixtures/apiResponses/java-goof.json
@@ -1,0 +1,2432 @@
+{
+    "ok": false,
+    "deprecated": "This endpoint is deprecated, please use list-all-aggregated-issues endpoint instead.\nhttps://snyk.docs.apiary.io/#reference/projects/aggregated-project-issues/list-all-aggregated-issues",
+    "issues": {
+      "vulnerabilities": [
+        {
+          "id": "SNYK-JAVA-ORGZEROTURNAROUND-31681",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGZEROTURNAROUND-31681",
+          "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+          "type": "vuln",
+          "description": "## Overview\r\n[`org.zeroturnaround:zt-zip`](https://github.com/zeroturnaround/zt-zip) is a library that helps to create, modify or extract ZIP archives.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip Slip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n\r\n## Vulnerable Method\r\nThis vulnerability appears in method `process` under class name `Unpacker` in `org/zeroturnaround/zip/ZipUtil.java` [[1]](https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff)\r\n\r\n\r\n## Remediation\r\nUpgrade `org.zeroturnaround:zt-zip` to version 1.13 or higher.\n\n## References\n- [GitHub Commit](https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff)\n- [Zip Slip Advisory](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.zeroturnaround:zt-zip@1.12"
+          ],
+          "package": "org.zeroturnaround:zt-zip",
+          "version": "1.12",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,1.13)"
+            ]
+          },
+          "publicationTime": "2018-05-31T07:32:02Z",
+          "disclosureTime": "2018-04-17T21:00:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-1002201"
+            ],
+            "CWE": [
+              "CWE-29"
+            ]
+          },
+          "credit": [
+            "Snyk Security research Team"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+          "cvssScore": 5.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 275
+        },
+        {
+          "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-31325",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31325",
+          "title": "Directory Traversal",
+          "type": "vuln",
+          "description": "## Overview\n[org.springframework:spring-core](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22spring-core%22) is a core package within the spring-framework that contains multiple classes and utilities.\n\nAffected versions of this package are vulnerable to Directory Traversal. It allows remote attackers to read arbitrary files via a crafted URL.\n\n## Details\n\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\n\nDirectory Traversal vulnerabilities can be generally divided into two types:\n\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\n\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\n\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\n\n```\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\n```\n**Note** `%2e` is the URL encoded version of `.` (dot).\n\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \n\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\n\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\n\n```\n2018-04-15 22:04:29 .....           19           19  good.txt\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\n```\n\n## Remediation\nUpgrade `org.springframework:spring-core` to version 3.2.9.RELEASE, 4.0.5.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/e3e71ba92a8b82dadf474eda76cd2741f65a77a8)\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/f6fddeb6eb7da625fd711ab371ff16512f431e8d)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/16414)\n- [Jira Issue](https://jira.spring.io/browse/SPR-12354)\n- [JVNDB](http://jvndb.jvn.jp/en/contents/2014/JVNDB-2014-000054.html)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3578)\n- [Pivotal Security](https://pivotal.io/security/cve-2014-3578)\n- [Pivotal Security](http://www.pivotal.io/security/cve-2014-3578)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1131882)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.springframework:spring-web@3.2.6.RELEASE",
+            "org.springframework:spring-core@3.2.6.RELEASE"
+          ],
+          "package": "org.springframework:spring-core",
+          "version": "3.2.6.RELEASE",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.0.0.RELEASE, 3.2.9.RELEASE)",
+              "[4.0.0.RELEASE, 4.0.5.RELEASE)"
+            ]
+          },
+          "publicationTime": "2014-09-05T17:16:58Z",
+          "disclosureTime": "2014-09-05T17:16:58Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2014-3578"
+            ],
+            "CWE": [
+              "CWE-22"
+            ]
+          },
+          "credit": [
+            "Takeshi Terada"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+          "cvssScore": 5.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 265
+        },
+        {
+          "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-31331",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31331",
+          "title": "Cross-site Request Forgery (CSRF)",
+          "type": "vuln",
+          "description": "## Overview\r\n[`org.springframework:spring-web`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22spring-web%22)\r\nAffected versions of this package do not disable external entity resolution, which allows remote attackers to read arbitrary files, cause a denial of service and conduct CSRF attacks via crafted XML, aka an XML External Entity (XXE) issue.  \r\n\r\n**NOTE:** this vulnerability exists because of an incomplete fix for [CVE-2013-4152](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31330), [CVE-2013-7315](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30162), and [CVE-2013-6429](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30160).\r\n\r\n## References\r\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0054)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.springframework:spring-web@3.2.6.RELEASE"
+          ],
+          "package": "org.springframework:spring-web",
+          "version": "3.2.6.RELEASE",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.0.0.RELEASE,3.2.8.RELEASE)",
+              "[4.0.0.RELEASE,4.0.2.RELEASE)"
+            ]
+          },
+          "publicationTime": "2014-06-06T21:43:43Z",
+          "disclosureTime": "2014-04-17T14:55:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2014-0054"
+            ],
+            "CWE": [
+              "CWE-352"
+            ]
+          },
+          "credit": [
+            "Spase Markovski"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:L",
+          "cvssScore": 6.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 315
+        },
+        {
+          "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30165",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30165",
+          "title": "Reflected File Download",
+          "type": "vuln",
+          "description": "## Overview\n\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\n\nAffected versions of this package are vulnerable to Reflected File Download\nvia a crafted URL with a batch script extension, resulting in the response being downloaded rather than rendered.\n\n## Remediation\n\nUpgrade `org.springframework:spring-web` to version 3.2.15.RELEASE, 4.1.8.RELEASE, 4.2.2.RELEASE or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/03f547eb9868f48f44d59b56067d4ac4740672c3)\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/2bd1daa75ee0b8ec33608ca6ab065ef3e1815543)\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/a95c3d820dbc4c3ae752f1b3ee22ee860b162402)\n\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/18124)\n\n- [Oren Hafif Blog](https://www.trustwave.com/Resources/SpiderLabs-Blog/Reflected-File-Download---A-New-Web-Attack-Vector/)\n\n- [Pivotal Security](http://pivotal.io/security/cve-2015-5211)\n\n- [RedHat CVE Database](https://access.redhat.com/security/cve/cve-2015-5211)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.springframework:spring-web@3.2.6.RELEASE"
+          ],
+          "package": "org.springframework:spring-web",
+          "version": "3.2.6.RELEASE",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.2.0.RELEASE, 3.2.15.RELEASE)",
+              "[4.0.0.RELEASE, 4.1.8.RELEASE)",
+              "[4.2.0.RELEASE, 4.2.2.RELEASE)"
+            ]
+          },
+          "publicationTime": "2016-12-25T16:51:56Z",
+          "disclosureTime": "2015-10-15T16:51:56Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2015-5211"
+            ],
+            "CWE": [
+              "CWE-494"
+            ]
+          },
+          "credit": [
+            "Alvaro Muñoz"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+          "cvssScore": 8.6,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 430
+        },
+        {
+          "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30164",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30164",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). It does not properly process inline DTD declarations when DTD is not entirely disabled, which allows remote attackers to cause a denial of service (memory consumption and out-of-memory errors) via a crafted XML file.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `org.springframework:spring-web` to version 3.2.14.RELEASE, 4.1.7.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/5a711c05ec750f069235597173084c2ee796242)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/17727)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3192)\n- [Pivotal Security](http://pivotal.io/security/cve-2015-3192)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.springframework:spring-web@3.2.6.RELEASE"
+          ],
+          "package": "org.springframework:spring-web",
+          "version": "3.2.6.RELEASE",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.2.0.RELEASE, 3.2.14.RELEASE)",
+              "[4.0.0.RELEASE, 4.1.7.RELEASE)"
+            ]
+          },
+          "publicationTime": "2016-12-25T16:51:55Z",
+          "disclosureTime": "2015-10-16T05:57:41Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2015-3192"
+            ],
+            "CWE": [
+              "CWE-119"
+            ]
+          },
+          "credit": [
+            "Toshiaki Maki"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+          "cvssScore": 5.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 275
+        },
+        {
+          "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30163",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30163",
+          "title": "XML External Entity (XXE) Injection",
+          "type": "vuln",
+          "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. This is due to not disabling the resolution of URI references by default in a DTD declaration. This occurs only when processing user provided XML documents.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `org.springframework:spring-web` to version 3.2.9.RELEASE, 4.0.5.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/8e096aeef55287dc829484996c9330cf755891a1)\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/c6503ebbf7c9e21ff022c58706dbac5417b2b5eb)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/16390)\n- [Pivotal Security](http://www.gopivotal.com/security/cve-2014-0225)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0225)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.springframework:spring-web@3.2.6.RELEASE"
+          ],
+          "package": "org.springframework:spring-web",
+          "version": "3.2.6.RELEASE",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.0.0.RELEASE,3.2.9.RELEASE)",
+              "[4.0.0.RELEASE,4.0.5.RELEASE)"
+            ]
+          },
+          "publicationTime": "2016-12-25T16:51:52Z",
+          "disclosureTime": "2016-12-25T16:51:52Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2014-0225"
+            ],
+            "CWE": [
+              "CWE-611"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "cvssScore": 8.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 440
+        },
+        {
+          "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-1009832",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-1009832",
+          "title": "Improper Input Validation",
+          "type": "vuln",
+          "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to Improper Input Validation. The protections against Reflected File Download attacks from CVE-2015-5211 may be bypassed depending on the browser used through the use of a `jsessionid` path parameter.\n## Remediation\nUpgrade `org.springframework:spring-web` to version 4.3.29.RELEASE, 5.0.19.RELEASE, 5.1.18.RELEASE, 5.2.9.RELEASE or higher.\n## References\n- [CVE-2015-5211](https://tanzu.vmware.com/security/cve-2015-5211)\n- [Pivotal Security Advisory](https://pivotal.io/security/cve-2020-5421)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.springframework:spring-web@3.2.6.RELEASE"
+          ],
+          "package": "org.springframework:spring-web",
+          "version": "3.2.6.RELEASE",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.2.0.RELEASE,4.3.29.RELEASE)",
+              "[5.0.0.RELEASE, 5.0.19.RELEASE)",
+              "[5.1.0.RELEASE, 5.1.18.RELEASE)",
+              "[5.2.0.RELEASE, 5.2.9.RELEASE)"
+            ]
+          },
+          "publicationTime": "2020-09-18T16:17:53Z",
+          "disclosureTime": "2020-09-18T14:23:55Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-5421"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+          "cvssScore": 8.6,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 430
+        },
+        {
+          "id": "SNYK-JAVA-ORGHIBERNATE-569100",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-569100",
+          "title": "Cross-site Scripting (XSS)",
+          "type": "vuln",
+          "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS). The `SafeHtml` validator annotation fails to properly sanitize payloads consisting of potentially malicious code in HTML comments and instructions.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 6.0.18.Final, 6.1.0.Final or higher.\n## References\n- [Apache Security Advisory](https://lists.apache.org/thread.html/r87b7e2d22982b4ca9f88f5f4f22a19b394d2662415b233582ed22ebf@%3Cnotifications.accumulo.apache.org%3E)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/124b7dd6d9a4ad24d4d49f74701f05a13e56ceee)\n- [Hibernator Security Release Blog](https://in.relation.to/2019/11/20/hibernate-validator-610-6018-released/)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-10219)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-validator@4.3.1.Final"
+          ],
+          "package": "org.hibernate:hibernate-validator",
+          "version": "4.3.1.Final",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,6.0.18.Final)",
+              "[6.1.0.Alpha1,6.1.0.Final)"
+            ]
+          },
+          "publicationTime": "2020-01-09T14:55:12Z",
+          "disclosureTime": "2018-10-18T14:55:21Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-10219"
+            ],
+            "CWE": [
+              "CWE-79"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N/E:U/RL:O/RC:R",
+          "cvssScore": 6.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 336
+        },
+        {
+          "id": "SNYK-JAVA-ORGHIBERNATE-568162",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-568162",
+          "title": "Improper Input Validation",
+          "type": "vuln",
+          "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to Improper Input Validation. A bug in the message interpolation processor enables invalid EL expressions to be evaluated as if they were valid. This flaw allows attackers to bypass input sanitation (escaping, stripping) controls that developers may have put in place when handling user-controlled data in error messages.\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 6.0.19.Final, 6.1.3.Final or higher.\n## References\n- [GitHub PR](https://github.com/hibernate/hibernate-validator/pull/1071)\n- [Jira Issue](https://hibernate.atlassian.net/browse/HV-1758)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1805501)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-validator@4.3.1.Final"
+          ],
+          "package": "org.hibernate:hibernate-validator",
+          "version": "4.3.1.Final",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,6.0.19.Final)",
+              "[6.1.0,6.1.3.Final)"
+            ]
+          },
+          "publicationTime": "2020-05-05T16:32:46Z",
+          "disclosureTime": "2020-05-05T00:00:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-10693"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Alvaro Muñoz"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cvssScore": 5.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 265
+        },
+        {
+          "id": "SNYK-JAVA-ORGHIBERNATE-30098",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-30098",
+          "title": "JSM bypass via ReflectionHelper",
+          "type": "vuln",
+          "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to JSM bypass via ReflectionHelper. ReflectionHelper (`org.hibernate.validator.util.ReflectionHelper`) in Hibernate Validator 4.1.0 before 4.2.1, 4.3.x before 4.3.2, and 5.x before 5.1.2 allows attackers to bypass Java Security Manager (JSM) restrictions and execute restricted reflection calls via a crafted application.\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 4.3.2.Final, 5.1.2.Final or higher.\n## References\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/2c95d4ea0ef20977be249e31a4a4f4f4f71c945d)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/67fdff14831c035c25e098fe14bd86523d17f726)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/7e7131939a4361a7cad3e77ab89a8462132c561c)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/c489416f699a46859c134796b3ccfea41ef3ce52)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/c9525ca544b1281e2b7c7347e86e87c86dc1dc6e)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/e8c42b689df8c6752d635d02c6518da3fece3870)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/f97c2021a03c825abdeca1692f5be51e77e76a8f)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/fd4eaed7fb930db6a5e4c03742b4b3adcfecc90e)\n- [Jira Issue](https://hibernate.atlassian.net/browse/HV-912)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2014-3558)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-validator@4.3.1.Final"
+          ],
+          "package": "org.hibernate:hibernate-validator",
+          "version": "4.3.1.Final",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[4.1.0.Beta1, 4.3.2.Final)",
+              "[5.0.0.Final,5.1.2.Final)"
+            ]
+          },
+          "publicationTime": "2014-07-17T16:51:53Z",
+          "disclosureTime": "2014-07-17T16:51:53Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2014-3558"
+            ],
+            "CWE": [
+              "CWE-592"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+          "cvssScore": 5.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 265
+        },
+        {
+          "id": "SNYK-JAVA-ORGHIBERNATE-584563",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-584563",
+          "title": "SQL Injection",
+          "type": "vuln",
+          "description": "## Overview\n[org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) is a library providing Object/Relational Mapping (ORM) support to applications, libraries, and frameworks.\n\nAffected versions of this package are vulnerable to SQL Injection. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SELECT or GROUP BY parts of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks.\n## Remediation\nUpgrade `org.hibernate:hibernate-core` to version 5.3.18.Final, 5.4.18.Final or higher.\n## References\n- [GitHub Pull Request](https://github.com/hibernate/hibernate-orm/pull/3438)\n- [Jira Ticket](https://hibernate.atlassian.net/browse/HHH-14077)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-core@4.3.7.Final"
+          ],
+          "package": "org.hibernate:hibernate-core",
+          "version": "4.3.7.Final",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,5.3.18.Final)",
+              "[5.4.0.Final, 5.4.18.Final)"
+            ]
+          },
+          "publicationTime": "2020-07-15T16:40:12Z",
+          "disclosureTime": "2020-06-18T13:46:30Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-14900"
+            ],
+            "CWE": [
+              "CWE-89"
+            ]
+          },
+          "credit": [
+            "Gail Badner"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 8.1,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 405
+        },
+        {
+          "id": "SNYK-JAVA-ORGHIBERNATE-1041788",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGHIBERNATE-1041788",
+          "title": "SQL Injection",
+          "type": "vuln",
+          "description": "## Overview\n[org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) is a library providing Object/Relational Mapping (ORM) support to applications, libraries, and frameworks.\n\nAffected versions of this package are vulnerable to SQL Injection. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SQL comments of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks. The highest threat from this vulnerability is to data confidentiality and integrity.\n## Remediation\nUpgrade `org.hibernate:hibernate-core` to version 5.4.24.Final or higher.\n## References\n- [GitHub Commit](https://github.com/hibernate/hibernate-orm/commit/59fede7acaaa1579b561407aefa582311f7ebe78)\n- [Redhat CVE Details](https://access.redhat.com/security/cve/cve-2020-25638)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-core@4.3.7.Final"
+          ],
+          "package": "org.hibernate:hibernate-core",
+          "version": "4.3.7.Final",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          "publicationTime": "2020-11-19T16:57:14.572204Z",
+          "disclosureTime": "2020-11-19T16:51:45Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-25638"
+            ],
+            "CWE": [
+              "CWE-89"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N/E:U/RL:O/RC:U",
+          "cvssScore": 8.2,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 421
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-474418",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-474418",
+          "title": "Insecure Defaults",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Insecure Defaults. The default exclude patterns (excludeParams) allow remote attackers to \"compromise internal state of an application\" via unspecified vectors.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.20.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/5ebc0643b55d728a6713a82559a594d875452cd8)\n- [GitHub Commit](https://github.com/apache/struts/commit/d832747d647df343ed07a58b1b5e540a05a4d51b)\n- [Jira Issue](https://issues.apache.org/jira/browse/WW-4486)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1831)\n- [Struts Security Advisory](https://struts.apache.org/docs/s2-024.html)\n- [Vulnerability Summary](http://struts.apache.org/docs/s2-024.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20,2.3.20.1)"
+            ]
+          },
+          "publicationTime": "2015-05-11T16:51:55Z",
+          "disclosureTime": "2015-05-11T16:51:55Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2015-1831"
+            ],
+            "CWE": [
+              "CWE-453"
+            ]
+          },
+          "credit": [
+            "Jasper Rosenberg"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "cvssScore": 7.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 365
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-451611",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-451611",
+          "title": "Command Injection",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Command Injection. When Dynamic Method Invocation was enabled, a remote attackers could execute arbitrary code via the prefix method, related to chained expressions.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/39756)\n- [GitHub Commit](https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.0.0, 2.3.20.2)",
+              "[2.3.24, 2.3.24.2)",
+              "[2.3.28, 2.3.28.1)"
+            ]
+          },
+          "publicationTime": "2016-04-22T04:32:51Z",
+          "disclosureTime": "2016-04-22T04:32:51Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-3081"
+            ],
+            "CWE": [
+              "CWE-77"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+          "cvssScore": 8.1,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 619
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30804",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30804",
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The URLValidator class allows remote attackers to cause a denial of service via a null value for a URL field.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.29 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152)\n- [GitHub Commit](https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20, 2.3.29)"
+            ]
+          },
+          "publicationTime": "2016-06-20T07:45:43Z",
+          "disclosureTime": "2016-06-20T07:45:43Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4465"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cvssScore": 5.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 265
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30803",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30803",
+          "title": "Arbitrary Code Execution",
+          "type": "vuln",
+          "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nAffected versions of the package are vulnerable to Remote code Execution. The Apache Struts frameworks when forced, performs double evaluation of attributes' values assigned to certain tags so it is possible to pass in a value that will be evaluated again when a tag's attributes will be rendered.\n\n## References\n- [Apache Security Advisory](https://struts.apache.org/docs/s2-036.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.2.1,2.3.28.1]"
+            ]
+          },
+          "publicationTime": "2016-11-14T07:48:03.440000Z",
+          "disclosureTime": "2016-11-14T07:48:03.440000Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4461"
+            ],
+            "CWE": [
+              "CWE-264"
+            ]
+          },
+          "credit": [
+            "Alvaro Munoz"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 8.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 440
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30802",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30802",
+          "title": "Access Restriction Bypass",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks via a crafted request.\n## Remediation\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20,2.3.28.1]"
+            ]
+          },
+          "publicationTime": "2016-06-21T01:33:07Z",
+          "disclosureTime": "2016-06-21T01:33:07Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4433"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Takeshi Terada"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30801",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30801",
+          "title": "Improper Input Validation",
+          "type": "vuln",
+          "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nApache Struts 2.0.0 through 2.3.24.1 does not properly cache method references when used with OGNL before 3.0.12, which allows remote attackers to cause a denial of service (block access to a web site) via unspecified vectors.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2,2.3.24.1]"
+            ]
+          },
+          "publicationTime": "2016-06-02T02:16:48.918000Z",
+          "disclosureTime": "2016-06-02T02:16:48.918000Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-3093"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cvssScore": 5.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 265
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30800",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30800",
+          "title": "Cross-site Scripting (XSS)",
+          "type": "vuln",
+          "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nApache Struts 2.x before 2.3.25 does not sanitize text in the Locale object constructed by I18NInterceptor, which might allow remote attackers to conduct cross-site scripting (XSS) attacks via unspecified vectors involving language display.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-2162)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2,2.3.25)"
+            ]
+          },
+          "publicationTime": "2016-03-16T07:51:26.242000Z",
+          "disclosureTime": "2016-03-16T07:51:26.242000Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-2162"
+            ],
+            "CWE": [
+              "CWE-79"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cvssScore": 6.1,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 305
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30799",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30799",
+          "title": "Improper Input Validation",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Improper Input Validation via a `%{}` sequence in a tag attribute, aka forced double OGNL evaluation.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.28 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/15857a69e7baf3675804495a5954cd0756ac8364)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2,2.3.28)"
+            ]
+          },
+          "publicationTime": "2016-03-16T05:58:06Z",
+          "disclosureTime": "2016-03-16T05:58:06Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-0785"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 8.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 440
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30798",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTSXWORK-30798",
+          "title": "Parameter Alteration",
+          "type": "vuln",
+          "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nAffected versions of the package are vulnerable to Parameter Alteration. ValueStack defines special top object which represents root of execution context. It can be used to manipulate Struts' internals or can be used to affect container's settings\n\n\n## References\n- [Apache Security Advisory](https://struts.apache.org/docs/s2-026.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "org.apache.struts.xwork:xwork-core@2.3.20"
+          ],
+          "package": "org.apache.struts.xwork:xwork-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2,2.3.24.1)"
+            ]
+          },
+          "publicationTime": "2015-09-28T16:59:30Z",
+          "disclosureTime": "2015-09-28T16:59:30Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2015-5209"
+            ],
+            "CWE": [
+              "CWE-235"
+            ]
+          },
+          "credit": [
+            "rskvp93"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-609765",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-609765",
+          "title": "Unrestricted Upload of File with Dangerous Type",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Unrestricted Upload of File with Dangerous Type. A local code execution issue exists in Apache Struts2 when processing malformed XSLT files, which could let a malicious user upload and execute arbitrary files.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5 or higher.\n## References\n- [Bug Report](https://issues.apache.org/jira/browse/WW-5055)\n- [GitHub Commit](https://github.com/apache/struts/commit/4271682d2b944e9022e4e4c499df43e0ce7e58fd)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,2.5)"
+            ]
+          },
+          "publicationTime": "2020-09-04T15:56:53Z",
+          "disclosureTime": "2019-12-05T15:43:54Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2012-1592"
+            ],
+            "CWE": [
+              "CWE-434"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 8.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 440
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-608098",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-608098",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When a file upload is performed to an `Action` that exposes the file with a getter, an attacker may manipulate the request such that the working copy of the uploaded file is set to read-only. As a result, subsequent actions on the file will fail with an error. It might also be possible to set the Servlet container's temp directory to read-only, such that subsequent upload actions will fail.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.22 or higher.\n## References\n- [Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-060)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "proof-of-concept",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.0.0, 2.5.22)"
+            ]
+          },
+          "publicationTime": "2020-08-21T14:36:29Z",
+          "disclosureTime": "2020-08-11T14:36:56Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-0233"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "credit": [
+            "Takeshi Terada of Mitsui Bussan Secure Directions",
+            "Inc"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 482
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-608097",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-608097",
+          "title": "Remote Code Execution (RCE)",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE). Forced double OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.22 or higher.\n## References\n- [Exploit](https://www.exploit-db.com/exploits/49068)\n- [Proof Of Concept](https://github.com/PrinceFPF/CVE-2019-0230)\n- [Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-059)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.0.0, 2.5.22)"
+            ]
+          },
+          "publicationTime": "2020-08-21T14:06:54Z",
+          "disclosureTime": "2020-08-11T14:14:01Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-0230"
+            ],
+            "CWE": [
+              "CWE-94"
+            ]
+          },
+          "credit": [
+            "Matthias Kaiser"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:O/RC:C",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 661
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-460223",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-460223",
+          "title": "Regular Expression Denial of Service (ReDoS)",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The URLValidator class allows remote attackers to cause a denial of service via a null value for a URL field.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29, 2.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152)\n- [GitHub Commit](https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20, 2.3.29)",
+              "[2.5,2.5.1)"
+            ]
+          },
+          "publicationTime": "2016-06-20T07:45:43Z",
+          "disclosureTime": "2016-06-20T07:45:43Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4465"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cvssScore": 5.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 265
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-451610",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-451610",
+          "title": "Improper Action Name Cleanup",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Improper Action Name Cleanup. It allowed attackers to have unspecified impact via vectors related to improper action name clean up.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29, 2.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/237432512df0e27013f7c7b9ab59fdce44ca34a5)\n- [GitHub Commit](https://github.com/apache/struts/commit/27ca165ddbf81c84bafbd083b99a18d89cc49ca7)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.0.0, 2.3.29)",
+              "[2.5, 2.5.1)"
+            ]
+          },
+          "publicationTime": "2016-09-19T05:25:51Z",
+          "disclosureTime": "2016-09-19T05:25:51Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4436"
+            ],
+            "CWE": [
+              "CWE-459"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 490
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-32477",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-32477",
+          "title": "Remote Code Execution",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution. When the namespace value is not set for a result defined in underlying xml configurations, and in same time, its upper action(s) configurations have no or wildcard namespace, an attacker may be able to conduct a remote code execution attack. They could also use the opportunity when using a url tag which does not have a value and action set and in same time, its upper action(s) configurations have no or wildcard namespace.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.35, 2.5.17 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/45367)\n- [Exploit DB](https://www.exploit-db.com/exploits/45367)\n- [GitHub Commit](https://github.com/apache/struts/commit/b3bad5ea44f3fd9edb2cb491192c5900f46d45d3)\n- [Lgtm Blog](https://lgtm.com/blog/apache_struts_CVE-2018-11776)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1620019)\n- [Struts2 Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-057)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.0, 2.3.35)",
+              "[2.5.0, 2.5.17)"
+            ]
+          },
+          "publicationTime": "2018-08-22T11:53:44Z",
+          "disclosureTime": "2018-08-17T00:00:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-11776"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Man Yue Mo"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+          "cvssScore": 8.1,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 619
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-31503",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31503",
+          "title": "Arbitrary Code Execution",
+          "type": "vuln",
+          "description": "## Overview\r\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution. An unauthenticated attack may be able to exploit this \r\nWhen using expression literals or forcing expression in Freemarker tags (see example below) and using request values can lead to RCE attack.\r\n\r\n```xml\r\n<@s.hidden name=\"redirectUri\" value=redirectUri />\r\n<@s.hidden name=\"redirectUri\" value=\"${redirectUri}\" />\r\n<@s.hidden name=\"${redirectUri}\"/>\r\n```\r\n\r\nIn both cases a writable property is used in the value attribute and in both cases this is threatened as an expression by Freemarker. Please be aware that using Struts expression evaluation style is safe:\r\n\r\n```\r\n<@s.hidden name=\"redirectUri\" value=\"%{redirectUri}\" />\r\n<@s.hidden name=\"%{redirectUri}\"/>\r\n```\r\n\r\n## Remediation\r\nDevelopers are strongly advised to upgrade their _Apache Struts_ components to version `2.3.34`, `2.5.12` or higher.\r\n\r\n## References\r\n- [Apache Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-053)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,2.3.34)",
+              "[2.4,2.5.12)"
+            ]
+          },
+          "publicationTime": "2017-09-06T17:28:23Z",
+          "disclosureTime": "2017-09-05T17:28:23Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2017-12611"
+            ],
+            "CWE": [
+              "CWE-20",
+              "CWE-502"
+            ]
+          },
+          "credit": [
+            "Lupin",
+            "David Greene",
+            "Roland McIntosh"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 661
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-31502",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31502",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (ReDoS) attacks. The REST Plugin is using outdated XStream library which is vulnerable and allow perform a DoS attack using malicious request with specially crafted XML payload.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.34, 2.5.13 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-051.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.7,2.3.34)",
+              "[2.5,2.5.13)"
+            ]
+          },
+          "publicationTime": "2017-09-12T12:47:32.905000Z",
+          "disclosureTime": "2017-08-23T21:00:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2017-9793"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "credit": [
+            "Huijun Chen",
+            "Xiaolong Zhu"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-31501",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31501",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks. This is due to an incomplete fix for [CVE-2017-7672](https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31499). If an application allows enter an URL in a form field and built-in URLValidator is used, it is possible to prepare a special URL which will be used to overload server process when performing validation of the URL.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.34, 2.5.13 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-050.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.7,2.3.34)",
+              "[2.5,2.5.13)"
+            ]
+          },
+          "publicationTime": "2017-09-12T12:47:32.905000Z",
+          "disclosureTime": "2017-08-23T21:00:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2017-9804"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "credit": [
+            "Adam Cazzolla",
+            "Jonathan Bullock"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-31500",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31500",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks.\nWhen using a Spring AOP functionality to secure Struts actions it is possible to perform a DoS attack.\n\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.33, 2.5.12 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-049.html)\n- [Struts Announcements Mailing List](https://lists.apache.org/thread.html/3795c4dd46d9ec75f4a6eb9eca11c11edd3e796c6c1fd7b17b5dc50d@%3Cannouncements.struts.apache.org%3E)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.7,2.3.33)",
+              "[2.5,2.5.12)"
+            ]
+          },
+          "publicationTime": "2017-09-12T12:47:32.905000Z",
+          "disclosureTime": "2017-07-13T15:29:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2017-9787"
+            ],
+            "CWE": [
+              "CWE-400"
+            ]
+          },
+          "credit": [
+            "Yasser Zamani"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-31495",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31495",
+          "title": "Arbitrary Command Execution",
+          "type": "vuln",
+          "description": "## Overview\r\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\r\n\r\nThe REST Plugin in affected versions use a `XStreamHandler` with an instance of XStream for deserialization without any type filtering. By design, there are few limits to the type of objects XStream can handle. This flexibility comes at a price. The XML generated or consumed by XStream includes all information required to build Java objects of almost any type. The provided XML data is used by XStream to unmarshal Java objects. An attacker could use this flaw to execute arbitrary code or conduct further attacks.\r\n\r\n[A working exploit](https://github.com/rapid7/metasploit-framework/commit/5ea83fee5ee8c23ad95608b7e2022db5b48340ef) is publicly available and [is actively](https://www.imperva.com/blog/2017/09/cve-2017-9805-analysis-of-apache-struts-rce-vulnerability-in-rest-plugin/) exploited in the wild.\r\n\r\nYou can read more about this vulnerability [on our blog](https://snyk.io/blog/equifax-breach-vulnerable-open-source-libraries/).\r\n\r\n# Details\r\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\r\n\r\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker control the state or the flow of the execution. \r\n\r\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\r\n\r\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\r\n\r\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\r\n- Apache Blog\r\n\r\n\r\n## Remediation\r\nDevelopers are strongly advised to upgrade their _Apache Struts_ components to version `2.3.34`, `2.5.13` or higher.\r\n\r\nIt is possible that some REST actions stop working because of applied default restrictions on available classes. In this case please investigate the new interfaces that were introduced to allow class restrictions per action, those interfaces are:\r\n* org.apache.struts2.rest.handler.AllowedClasses\r\n* org.apache.struts2.rest.handler.AllowedClassNames\r\n* org.apache.struts2.rest.handler.XStreamPermissionProvider\r\n\r\nIf for some reason upgrading is not an option, consider the following workarounds:\r\n1. Disable handling XML pages and requests to such pages\r\n```xml\r\n<constant name=\"struts.action.extension\" value=\"xhtml,,json\" />\r\n```\r\n\r\n2. Override getContentType in XStreamHandler\r\n```java\r\n public class MyXStreamHandler extends XStreamHandler { \r\n   public String getContentType() {\r\n     return \"not-existing-content-type-@;/&%$#@\";\r\n   }\r\n }\r\n```\r\n\r\n3. Register the handler by overriding the one provided by the framework in your struts.xml\r\n```xml\r\n<bean type=\"org.apache.struts2.rest.handler.ContentTypeHandler\" name=\"myXStreamHandmer\" class=\"com.company.MyXStreamHandler\"/>\r\n<constant name=\"struts.rest.handlerOverride.xml\" value=\"myXStreamHandler\"/>\r\n```\r\n\r\n## References\r\n- [LGTM Advisory](https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement)\r\n- [LGTM Vulnerability Details](https://lgtm.com/blog/apache_struts_CVE-2017-9805)\r\n- [Apache Struts Statement on Equifax Security Breach](https://blogs.apache.org/foundation/entry/apache-struts-statement-on-equifax)\r\n- [Apache Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-052)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,2.3.34)",
+              "[2.4,2.5.13)"
+            ]
+          },
+          "publicationTime": "2017-09-06T17:28:23Z",
+          "disclosureTime": "2017-09-05T17:28:23Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2017-9805"
+            ],
+            "CWE": [
+              "CWE-20",
+              "CWE-502"
+            ]
+          },
+          "credit": [
+            "LGTM Security Team"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:O/RC:R",
+          "cvssScore": 8.1,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 576
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30778",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30778",
+          "title": "Directory Traversal",
+          "type": "vuln",
+          "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\nAffected versions of the package are vulnerable to Directory Traversal.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n\n\n## References\n- [Apache Security Advisory](http://struts.apache.org/docs/s2-042.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20,2.3.31)"
+            ]
+          },
+          "publicationTime": "2016-10-19T01:09:09.263000Z",
+          "disclosureTime": "2016-10-19T01:09:09.263000Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-6795"
+            ],
+            "CWE": [
+              "CWE-94"
+            ]
+          },
+          "credit": [
+            "Takeshi Terada"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 490
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30776",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30776",
+          "title": "Access Restriction Bypass",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks via a crafted request.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20, 2.3.29)"
+            ]
+          },
+          "publicationTime": "2016-06-21T01:33:07Z",
+          "disclosureTime": "2016-06-21T01:33:07Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4433"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Takeshi Terada"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30775",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30775",
+          "title": "Access Restriction Bypass",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks by leveraging a default method.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [Apache Struts Security Bulletin](https://struts.apache.org/docs/s2-040.html)\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4431)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20,2.3.29)"
+            ]
+          },
+          "publicationTime": "2016-06-21T04:49:27Z",
+          "disclosureTime": "2016-06-21T04:49:27Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4431"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Takeshi Terada"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30774",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30774",
+          "title": "Cross-site Request Forgery (CSRF)",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Cross-site Request Forgery (CSRF). It mishandles token validation, which allows remote attackers to conduct CSRF attacks via unspecified vectors.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [Apache Struts Security Bulletin](https://struts.apache.org/docs/s2-038.html)\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4430)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.20,2.3.29)"
+            ]
+          },
+          "publicationTime": "2016-06-20T07:00:37Z",
+          "disclosureTime": "2016-06-20T07:00:37Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4430"
+            ],
+            "CWE": [
+              "CWE-352"
+            ]
+          },
+          "credit": [
+            "Takeshi Terada"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+          "cvssScore": 8.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 440
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30773",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30773",
+          "title": "Cross-site Scripting (XSS)",
+          "type": "vuln",
+          "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\nCross-site Scripting (XSS) vulnerability in the URLDecoder function in JRE before 1.8, as used in Apache Struts 2.x before 2.3.28, when using a single byte page encoding, allows remote attackers to inject arbitrary web script or HTML via multi-byte characters in a url-encoded parameter.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4003)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,2.3.28)"
+            ]
+          },
+          "publicationTime": "2016-03-16T06:52:13.014000Z",
+          "disclosureTime": "2016-03-16T06:52:13.014000Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-4003"
+            ],
+            "CWE": [
+              "CWE-79"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+          "cvssScore": 6.1,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 305
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30772",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30772",
+          "title": "Arbitrary Command Execution",
+          "type": "vuln",
+          "description": "## Overview\r\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\r\nApache Struts 2.3.20.x before 2.3.20.3, 2.3.24.x before 2.3.24.3, and 2.3.28.x before 2.3.28.1, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via vectors related to an ! (exclamation mark) operator to the REST Plugin.\r\n\r\n## References\r\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3087)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2,2.3.20.2)",
+              "[2.3.24,2.3.24.3)",
+              "[2.3.28,2.3.28.1)"
+            ]
+          },
+          "publicationTime": "2016-06-02T00:40:36Z",
+          "disclosureTime": "2016-06-02T00:40:36Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-3087"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 704
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30771",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30771",
+          "title": "Arbitrary Code Execution",
+          "type": "vuln",
+          "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22) is a free open-source solution for creating Java web applications.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. It allows remote attackers to execute arbitrary code via the stylesheet location parameter.\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3082)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2,2.3.20.2)",
+              "[2.3.24,2.3.24.2)",
+              "[2.3.28,2.3.28.1)"
+            ]
+          },
+          "publicationTime": "2016-04-22T02:36:52.273000Z",
+          "disclosureTime": "2016-04-22T02:36:52.273000Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-3082"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 490
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30770",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30770",
+          "title": "Command Injection",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Command Injection. When Dynamic Method Invocation was enabled, a remote attackers could execute arbitrary code via the prefix method, related to chained expressions.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/39756)\n- [GitHub Commit](https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.0.0, 2.3.20.2)",
+              "[2.3.24, 2.3.24.2)",
+              "[2.3.28, 2.3.28.1)"
+            ]
+          },
+          "publicationTime": "2016-04-22T04:32:51Z",
+          "disclosureTime": "2016-04-22T04:32:51Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-3081"
+            ],
+            "CWE": [
+              "CWE-77"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+          "cvssScore": 8.1,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 619
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30207",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30207",
+          "title": "Arbitrary Code Execution",
+          "type": "vuln",
+          "description": "## Overview\r\n[`org.apache.struts:struts2-core`](https://cwiki.apache.org/confluence/display/WW/Home) is an elegant, extensible framework for building enterprise-ready Java web applications.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary Command Execution while uploading files with the Jakarta Multipart parser. This particular vulnerability can be exploited by an attacker by sending a crafted request to upload a file to the vulnerable server that uses a Jakarta-based plugin to process the upload request.\r\n\r\nThe attacker can then send malicious code in the `Content-Type`, `Content-Disposition` or `Content-Length` HTTP headers, which will then be executed by the vulnerable server. [A proof of concept](https://github.com/tengzhangchao/Struts2_045-Poc) that demonstrates the attack scenario is publicly available and the vulnerability is being [actively exploited in the wild](https://www.theregister.co.uk/2017/03/09/apache_under_attack_patch_for_zero_day_available/).\r\n\r\nAlthough maintainers of the open source project immediately patched the vulnerability, Struts servers that have yet to install the update remain under attack by hackers who exploit it to inject commands of their choice.\r\n\r\nThis attack can be achieved without authentication. To make matters worse, web applications don't necessarily need to successfully upload a malicious file to exploit this vulnerability, as just the presence of the vulnerable Struts library within an application is enough to exploit the vulnerability.\r\n\r\n## Remediation\r\nUpgrade `org.apache.struts:struts2-core` to version 2.3.32, 2.5.10.1 or higher.\n\n## References\n- [CVE Details](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638)\n- [Exploit DB](https://exploit-db.com/exploits/41614)\n- [Exploit DB](https://www.exploit-db.com/exploits/41570/)\n- [GitHub Commit](https://github.com/rapid7/metasploit-framework/pull/8072/commits/fc0f63e77471baa40057effaaa8be0f205adc6b7)\n- [GitHub Issue](https://github.com/rapid7/metasploit-framework/issues/8064)\n- [GitHub PR](https://github.com/rapid7/metasploit-framework/pull/8072)\n- [PoC](https://github.com/tengzhangchao/Struts2_045-Poc)\n- [Struts Wiki](https://cwiki.apache.org/confluence/display/WW/S2-045)\n- [Talos Intelligence Blog](http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "mature",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.3.7, 2.3.32)",
+              "[2.5.0, 2.5.10.1)"
+            ]
+          },
+          "publicationTime": "2017-03-21T15:30:44Z",
+          "disclosureTime": "2017-03-05T22:00:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2017-5638"
+            ],
+            "CWE": [
+              "CWE-94"
+            ]
+          },
+          "credit": [
+            "Nike Zheng"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:F/RL:O/RC:C",
+          "cvssScore": 10,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 671
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-30060",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-30060",
+          "title": "Manipulation of Struts' internals",
+          "type": "vuln",
+          "description": "## Overview\n`ValueStack` defines special `top` object which represents root of execution context. It can be used to manipulate Struts' internals or can be used to affect container's settings.\n\n## References\n- [Vulnerability Summary](http://struts.apache.org/docs/s2-026.html)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.0.0, 2.3.24.1)"
+            ]
+          },
+          "publicationTime": "2015-07-01T16:51:56Z",
+          "disclosureTime": "2015-07-01T16:51:56Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2015-5209"
+            ],
+            "CWE": [
+              "CWE-284"
+            ]
+          },
+          "credit": [
+            "Viettel Information Security Center"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-ORGAPACHESTRUTS-1049003",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-1049003",
+          "title": "Remote Code Execution (RCE)",
+          "type": "vuln",
+          "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE). The vulnerability exists due to improper input validation when processing certain tag's attributes. The application performs double evaluation of the code if a developer applied forced OGNL evaluation by using the `%{...}` syntax. A remote attacker can send a specially crafted request to the application and execute arbitrary code on the target system.\r\n\r\nSuccessful exploitation of this vulnerability may result in complete compromise of vulnerable system.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.26 or higher.\n## References\n- [Apache Security Advisory](https://cwiki.apache.org/confluence/display/WW/S2-061)\n- [GitHub Commit](https://github.com/apache/struts/commit/45667346629455f7ea125bff36bf9b763b7e8463)\n- [PoC](https://github.com/phil-fly/CVE-2020-17530)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20"
+          ],
+          "package": "org.apache.struts:struts2-core",
+          "version": "2.3.20",
+          "severity": "high",
+          "exploitMaturity": "proof-of-concept",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[2.0.0, 2.5.26)"
+            ]
+          },
+          "publicationTime": "2020-12-08T19:25:43Z",
+          "disclosureTime": "2020-12-08T19:25:45Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2020-17530"
+            ],
+            "CWE": [
+              "CWE-94"
+            ]
+          },
+          "credit": [
+            "Alvaro Munoz",
+            "Masato Anzai"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 597
+        },
+        {
+          "id": "SNYK-JAVA-OGNL-30474",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-OGNL-30474",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[`ognl:ognl`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22ognl%22) is a simple Expression Language (EL) for Java.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks.\nApache Struts 2.0.0 through 2.3.24.1 does not properly cache method references when used with OGNL before 3.0.12, which allows remote attackers to cause a denial of service (block access to a web site) via unspecified vectors.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `ognl:ognl` to version 3.0.12 or higher.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093)\n- [GitHub Commit](https://github.com/jkuhnert/ognl/commit/ae43073fbf38db8371ff4f8bf2a966ee3b5f7e92)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "ognl:ognl@3.0.6"
+          ],
+          "package": "ognl:ognl",
+          "version": "3.0.6",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,3.0.12)"
+            ]
+          },
+          "publicationTime": "2016-06-02T02:16:48.918000Z",
+          "disclosureTime": "2016-06-02T02:16:48.918000Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-3093"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "Tao Wang"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+          "cvssScore": 5.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 265
+        },
+        {
+          "id": "SNYK-JAVA-JAVAXSERVLET-30449",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-JAVAXSERVLET-30449",
+          "title": "XML External Entity (XXE) Injection",
+          "type": "vuln",
+          "description": "## Overview\n[javax.servlet:jstl](https://mvnrepository.com/artifact/javax.servlet/jstl) is a collection of useful JSP tags which encapsulates the core functionality common to many JSP applications.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity (XXE) attacks via a crafted XSLT extension in a `<x:parse>` or `<x:transform>` JSTL XML tag.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `javax.servlet:jstl`.\n## References\n- [Apache Mail Archive](http://mail-archives.us.apache.org/mod_mbox/www-announce/201502.mbox/%3C82207A16-6348-4DEE-877E-F7B87292576A@apache.org%3E)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254)\n- [RedHat CVE Database](https://access.redhat.com/security/cve/CVE-2015-0254)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "javax.servlet:jstl@1.2"
+          ],
+          "package": "javax.servlet:jstl",
+          "version": "1.2",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,]"
+            ]
+          },
+          "publicationTime": "2015-02-27T16:51:55Z",
+          "disclosureTime": "2015-02-27T16:13:27Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2015-0254"
+            ],
+            "CWE": [
+              "CWE-94"
+            ],
+            "GHSA": [
+              "GHSA-6x4w-8w53-xrvv"
+            ]
+          },
+          "credit": [
+            "David Jorm"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+          "cvssScore": 7.3,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 365
+        },
+        {
+          "id": "SNYK-JAVA-DOM4J-174153",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-DOM4J-174153",
+          "title": "XML External Entity (XXE) Injection",
+          "type": "vuln",
+          "description": "## Overview\n[dom4j:dom4j](https://github.com/dom4j/dom4j) is a flexible XML framework for Java. *Note*: this artifact has been deprecated for `org.dom4j:dom4j`.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection due to not validating the `QName` inputs.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `dom4j:dom4j`.\n## References\n- [GitHub Commit](https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387)\n- [GitHub Issue](https://github.com/dom4j/dom4j/issues/48)\n- [Ihacktoprotect Blog](https://ihacktoprotect.com/post/dom4j-xml-injection/)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-core@4.3.7.Final",
+            "dom4j:dom4j@1.6.1"
+          ],
+          "package": "dom4j:dom4j",
+          "version": "1.6.1",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,]"
+            ]
+          },
+          "publicationTime": "2018-08-21T14:16:13Z",
+          "disclosureTime": "2018-07-01T19:12:29Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-1000632"
+            ],
+            "CWE": [
+              "CWE-611"
+            ],
+            "GHSA": [
+              "GHSA-6pcc-3rfx-4gpm"
+            ]
+          },
+          "credit": [
+            "Mario Areias"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-COMMONSFILEUPLOAD-31540",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-31540",
+          "title": "Information Exposure",
+          "type": "vuln",
+          "description": "## Overview\r\n[`commons-fileupload:commons-fileupload`](https://commons.apache.org/proper/commons-fileupload/) provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\r\n\r\nAffected versions of the package are vulnerable to Information Disclosure because the `InputStream` is not closed on exception.\r\n\r\n## Remediation\r\nUpgrade `commons-fileupload` to version 1.3.2 or higher.\r\n\r\n## References\r\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L56)\r\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814)",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "commons-fileupload:commons-fileupload@1.3.1"
+          ],
+          "package": "commons-fileupload:commons-fileupload",
+          "version": "1.3.1",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[,1.3.2)"
+            ]
+          },
+          "publicationTime": "2017-02-17T08:05:48Z",
+          "disclosureTime": "2014-02-17T22:00:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [],
+            "CWE": [
+              "CWE-200"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+          "cvssScore": 6.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 325
+        },
+        {
+          "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30401",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30401",
+          "title": "Arbitrary Code Execution",
+          "type": "vuln",
+          "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nThe Apache Commons FileUpload library contains a Java Object that, upon deserialization, can be manipulated to write or copy files in arbitrary locations. If integrated with [`ysoserial`](https://github.com/frohoff/ysoserial), it is possible to upload and execute binaries in a single deserialization call.\n\n# Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n- Apache Blog\n\n## Remediation\nUpgrade `commons-fileupload` to version 1.3.3 or higher.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031)\n- [Tenable Security](http://www.tenable.com/security/research/tra-2016-12)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L65)\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "commons-fileupload:commons-fileupload@1.3.1"
+          ],
+          "package": "commons-fileupload:commons-fileupload",
+          "version": "1.3.1",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[1.1,1.3.3)"
+            ]
+          },
+          "publicationTime": "2016-10-26T03:04:11.895000Z",
+          "disclosureTime": "2016-10-25T14:29:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-1000031"
+            ],
+            "CWE": [
+              "CWE-284"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 490
+        },
+        {
+          "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30082",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-COMMONSFILEUPLOAD-30082",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[commons-fileupload:commons-fileupload](https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload) is a component that provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). It allows remote attackers to cause a denial of service (CPU consumption) via a long boundary string.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `commons-fileupload:commons-fileupload` to version 1.3.2 or higher.\n## References\n- [Apache Mail Archive](http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E)\n- [Apache-SVN](http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h)\n- [CVE Details](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L84)\n- [GitHub Commit](https://github.com/apache/tomcat80/commit/d752a415a875e888d8c8d0988dfbde95c2c6fb1d)\n- [GitHub Commit](https://github.com/apache/tomcat/commit/2c3553f3681baf775c50bb0b49ea61cb44ea914f)\n- [GitHub Commit](https://github.com/apache/tomcat/commit/8999f8243197a5f8297d0cb1a0d86ed175678a77)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1349475)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "org.apache.struts:struts2-core@2.3.20",
+            "commons-fileupload:commons-fileupload@1.3.1"
+          ],
+          "package": "commons-fileupload:commons-fileupload",
+          "version": "1.3.1",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[1.3,1.3.2)"
+            ]
+          },
+          "publicationTime": "2016-12-25T16:51:56Z",
+          "disclosureTime": "2016-06-22T16:51:56Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2016-3092"
+            ],
+            "CWE": [
+              "CWE-20"
+            ]
+          },
+          "credit": [
+            "TERASOLUNA Framework Development Team"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+          "cvssScore": 7.5,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 375
+        },
+        {
+          "id": "SNYK-JAVA-C3P0-461018",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-C3P0-461018",
+          "title": "Denial of Service (DoS)",
+          "type": "vuln",
+          "description": "## Overview\n[c3p0:c3p0](https://mvnrepository.com/artifact/c3p0/c3p0) is a lIbrary for augmenting traditional (DriverManager-based) JDBC drivers with JNDI-bindable DataSources, including DataSources that implement Connection and Statement Pooling, as described by the jdbc3 spec and jdbc2 std extension. Note: This library is no longer maintained and has migrated to the artifact \r\n\"com.mchange:c3p0\"\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to missing protections against recursive entity expansion when loading XML configurations.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nThere is no fixed version for `c3p0:c3p0`.\n## References\n- [Hackerone Report](https://hackerone.com/reports/509315)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "c3p0:c3p0@0.9.1.2"
+          ],
+          "package": "c3p0:c3p0",
+          "version": "0.9.1.2",
+          "severity": "medium",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,]"
+            ]
+          },
+          "publicationTime": "2019-04-22T22:18:26Z",
+          "disclosureTime": "2019-04-22T22:18:26Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2019-5427"
+            ],
+            "CWE": [
+              "CWE-776"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:O",
+          "cvssScore": 5.9,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 295
+        },
+        {
+          "id": "SNYK-JAVA-C3P0-461017",
+          "url": "https://snyk.io/vuln/SNYK-JAVA-C3P0-461017",
+          "title": "XML External Entity (XXE) Injection",
+          "type": "vuln",
+          "description": "## Overview\n\n[c3p0:c3p0](https://mvnrepository.com/artifact/c3p0/c3p0) is a lIbrary for augmenting traditional (DriverManager-based) JDBC drivers with JNDI-bindable DataSources, including DataSources that implement Connection and Statement Pooling, as described by the jdbc3 spec and jdbc2 std extension. Note: This library is no longer maintained and has migrated to the artifact \r\n\"com.mchange:c3p0\"\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nvia the `extractXmlConfigFromInputStream` in `com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java` during initialization.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n\n## Remediation\n\nThere is no fixed version for `c3p0:c3p0`.\n\n\n## References\n\n- [GitHub Commit](https://github.com/swaldman/c3p0/commit/7dfdda63f42759a5ec9b63d725b7412f74adb3e1)\n",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "c3p0:c3p0@0.9.1.2"
+          ],
+          "package": "c3p0:c3p0",
+          "version": "0.9.1.2",
+          "severity": "high",
+          "exploitMaturity": "no-known-exploit",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,]"
+            ]
+          },
+          "publicationTime": "2019-07-21T14:22:18Z",
+          "disclosureTime": "2018-12-24T13:29:00Z",
+          "isUpgradable": false,
+          "isPatchable": false,
+          "isPinnable": false,
+          "identifiers": {
+            "CVE": [
+              "CVE-2018-20433"
+            ],
+            "CWE": [
+              "CWE-611"
+            ]
+          },
+          "credit": [
+            "Unknown"
+          ],
+          "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+          "cvssScore": 9.8,
+          "patches": [],
+          "upgradePath": [],
+          "priorityScore": 490
+        }
+      ],
+      "licenses": [
+        {
+          "id": "snyk:lic:maven:org.jboss.logging:jboss-logging:LGPL-2.1",
+          "url": "https://snyk.io/vuln/snyk:lic:maven:org.jboss.logging:jboss-logging:LGPL-2.1",
+          "title": "LGPL-2.1 license",
+          "type": "license",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-validator@4.3.1.Final",
+            "org.jboss.logging:jboss-logging@3.1.0.CR2"
+          ],
+          "package": "org.jboss.logging:jboss-logging",
+          "version": "3.1.0.CR2",
+          "severity": "medium",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.0.1.GA, 3.1.2.GA)"
+            ]
+          }
+        },
+        {
+          "id": "snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0",
+          "url": "https://snyk.io/vuln/snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0",
+          "title": "LGPL-2.0 license",
+          "type": "license",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-entitymanager@4.3.7.Final"
+          ],
+          "package": "org.hibernate:hibernate-entitymanager",
+          "version": "4.3.7.Final",
+          "severity": "medium",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.5.0.Beta-1, 5.3.1.Final)"
+            ]
+          }
+        },
+        {
+          "id": "snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0",
+          "url": "https://snyk.io/vuln/snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0",
+          "title": "EPL-1.0 license",
+          "type": "license",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-core@4.3.7.Final",
+            "org.hibernate.javax.persistence:hibernate-jpa-2.1-api@1.0.0.Final"
+          ],
+          "package": "org.hibernate.javax.persistence:hibernate-jpa-2.1-api",
+          "version": "1.0.0.Final",
+          "severity": "medium",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,)"
+            ]
+          }
+        },
+        {
+          "id": "snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1",
+          "url": "https://snyk.io/vuln/snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1",
+          "title": "LGPL-2.1 license",
+          "type": "license",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-core@4.3.7.Final",
+            "org.hibernate.common:hibernate-commons-annotations@4.0.5.Final"
+          ],
+          "package": "org.hibernate.common:hibernate-commons-annotations",
+          "version": "4.0.5.Final",
+          "severity": "medium",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,)"
+            ]
+          }
+        },
+        {
+          "id": "snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0",
+          "url": "https://snyk.io/vuln/snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0",
+          "title": "EPL-1.0 license",
+          "type": "license",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.aspectj:aspectjweaver@1.8.2"
+          ],
+          "package": "org.aspectj:aspectjweaver",
+          "version": "1.8.2",
+          "severity": "medium",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,)"
+            ]
+          }
+        },
+        {
+          "id": "snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0",
+          "url": "https://snyk.io/vuln/snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0",
+          "title": "LGPL-2.0 license",
+          "type": "license",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "org.hibernate:hibernate-core@4.3.7.Final"
+          ],
+          "package": "org.hibernate:hibernate-core",
+          "version": "4.3.7.Final",
+          "severity": "medium",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[3.3.0.CR1, 5.3.1.Final)"
+            ]
+          }
+        },
+        {
+          "id": "snyk:lic:maven:c3p0:c3p0:LGPL-3.0",
+          "url": "https://snyk.io/vuln/snyk:lic:maven:c3p0:c3p0:LGPL-3.0",
+          "title": "LGPL-3.0 license",
+          "type": "license",
+          "from": [
+            "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+            "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+            "c3p0:c3p0@0.9.1.2"
+          ],
+          "package": "c3p0:c3p0",
+          "version": "0.9.1.2",
+          "severity": "medium",
+          "language": "java",
+          "packageManager": "maven",
+          "semver": {
+            "vulnerable": [
+              "[0,)"
+            ]
+          }
+        }
+      ]
+    },
+    "dependencyCount": 53,
+    "packageManager": "maven"
+  }

--- a/test/fixtures/snykTestsOutputs/test-goof-without-more-vuln-following-upgrade.json
+++ b/test/fixtures/snykTestsOutputs/test-goof-without-more-vuln-following-upgrade.json
@@ -1,0 +1,1944 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-03-07T00:18:41.509507Z",
+      "credit": [
+        "Peter van der Zee"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n\n[acorn](https://github.com/acornjs/acorn) is a tiny, fast JavaScript parser written in JavaScript.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nvia a regex in the form of `/[x-\\ud800]/u`, which causes the parser to enter an infinite loop. \r\n\r\nThis string is not a valid `UTF16` and is therefore not sanitized before reaching the parser. An application which processes untrusted input and passes it directly to `acorn`, will allow attackers to leverage the vulnerability leading to a Denial of Service.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `acorn` to version 5.7.4, 6.4.1, 7.1.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802)\n\n- [GitHub Issue 6.x Branch](https://github.com/acornjs/acorn/issues/929)\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1488)\n",
+      "disclosureTime": "2020-03-02T19:21:25Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "5.7.4",
+        "6.4.1",
+        "7.1.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-ACORN-559469",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-400"
+        ],
+        "GHSA": [
+          "GHSA-6chw-6frg-f759"
+        ],
+        "NSP": [
+          1488
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-03-10T10:19:13.616093Z",
+      "moduleName": "acorn",
+      "packageManager": "npm",
+      "packageName": "acorn",
+      "patches": [],
+      "publicationTime": "2020-03-07T00:19:23Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802"
+        },
+        {
+          "title": "GitHub Issue 6.x Branch",
+          "url": "https://github.com/acornjs/acorn/issues/929"
+        },
+        {
+          "title": "NPM Security Advisory",
+          "url": "https://www.npmjs.com/advisories/1488"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          ">=5.5.0 <5.7.4",
+          ">=6.0.0 <6.4.1",
+          ">=7.0.0 <7.1.1"
+        ]
+      },
+      "severity": "high",
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "from": [
+        "goof@0.0.3",
+        "@snyk/nodejs-runtime-agent@1.14.0",
+        "acorn@5.7.3"
+      ],
+      "upgradePath": [
+        false,
+        "@snyk/nodejs-runtime-agent@1.14.0",
+        "acorn@5.7.4"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "acorn",
+      "version": "5.7.3"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-01-28T15:18:37.743372Z",
+      "credit": [
+        "aaron_costello"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[dot-prop](https://github.com/sindresorhus/dot-prop#readme) is a package to get, set, or delete a property from a nested object using a dot path.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nIt is possible for a user to modify the prototype of a base object.\r\n\r\n## PoC by aaron_costello \r\n```\r\nvar dotProp = require(\"dot-prop\")\r\nconst object = {};\r\nconsole.log(\"Before \" + object.b); //Undefined\r\ndotProp.set(object, '__proto__.b', true);\r\nconsole.log(\"After \" + {}.b); //true\r\n```\n\n## Remediation\n\nUpgrade `dot-prop` to version 5.1.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2)\n\n- [HackerOne Report](https://hackerone.com/reports/719856)\n",
+      "disclosureTime": "2020-01-28T10:17:51Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "5.1.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-DOTPROP-543489",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-8116"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-01-31T17:21:49.331710Z",
+      "moduleName": "dot-prop",
+      "packageManager": "npm",
+      "packageName": "dot-prop",
+      "patches": [],
+      "publicationTime": "2020-01-28T16:23:39Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/719856"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<5.1.1"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "goof@0.0.3",
+        "snyk@1.228.3",
+        "configstore@3.1.2",
+        "dot-prop@4.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "snyk@1.290.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "dot-prop",
+      "version": "4.2.0"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-01-28T15:18:37.743372Z",
+      "credit": [
+        "aaron_costello"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\n\n[dot-prop](https://github.com/sindresorhus/dot-prop#readme) is a package to get, set, or delete a property from a nested object using a dot path.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nIt is possible for a user to modify the prototype of a base object.\r\n\r\n## PoC by aaron_costello \r\n```\r\nvar dotProp = require(\"dot-prop\")\r\nconst object = {};\r\nconsole.log(\"Before \" + object.b); //Undefined\r\ndotProp.set(object, '__proto__.b', true);\r\nconsole.log(\"After \" + {}.b); //true\r\n```\n\n## Remediation\n\nUpgrade `dot-prop` to version 5.1.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2)\n\n- [HackerOne Report](https://hackerone.com/reports/719856)\n",
+      "disclosureTime": "2020-01-28T10:17:51Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "5.1.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-DOTPROP-543489",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-8116"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-01-31T17:21:49.331710Z",
+      "moduleName": "dot-prop",
+      "packageManager": "npm",
+      "packageName": "dot-prop",
+      "patches": [],
+      "publicationTime": "2020-01-28T16:23:39Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/sindresorhus/dot-prop/commit/3039c8c07f6fdaa8b595ec869ae0895686a7a0f2"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/719856"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<5.1.1"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "goof@0.0.3",
+        "snyk@1.228.3",
+        "update-notifier@2.5.0",
+        "configstore@3.1.2",
+        "dot-prop@4.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "snyk@1.290.1"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "dot-prop",
+      "version": "4.2.0"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2019-10-22T12:22:54.665794Z",
+      "credit": [
+        "Roman Burunkov"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n\n[express-fileupload](https://github.com/richardgirges/express-fileupload) is a file upload middleware for express that wraps around busboy.\n\n\nAffected versions of this package are vulnerable to Denial of Service (DoS).\nThe package does not limit file name length.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\n\nUpgrade `express-fileupload` to version 1.1.6-alpha.6 or higher.\n\n\n## References\n\n- [GitHub PR](https://github.com/richardgirges/express-fileupload/pull/171)\n",
+      "disclosureTime": "2019-10-18T11:17:09Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.1.6-alpha.6"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-EXPRESSFILEUPLOAD-473997",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-79"
+        ],
+        "NSP": [
+          1216
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-11-20T09:48:38.528931Z",
+      "moduleName": "express-fileupload",
+      "packageManager": "npm",
+      "packageName": "express-fileupload",
+      "patches": [],
+      "publicationTime": "2019-10-22T15:08:40Z",
+      "references": [
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/richardgirges/express-fileupload/pull/171"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<1.1.6-alpha.6"
+        ]
+      },
+      "severity": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "goof@0.0.3",
+        "express-fileupload@0.0.5"
+      ],
+      "upgradePath": [
+        false,
+        "express-fileupload@1.1.6"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "express-fileupload",
+      "version": "0.0.5"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:A/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N/E:P/RL:U/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2019-09-26T10:01:07.677036Z",
+      "credit": [
+        "Kris Adler"
+      ],
+      "cvssScore": 6.1,
+      "description": "## Overview\n\n[https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent#readme) is a module that provides an http.Agent implementation that connects to a specified HTTP or HTTPS proxy server, and can be used with the built-in https module.\n\n\nAffected versions of this package are vulnerable to Man-in-the-Middle (MitM).\nWhen targeting a HTTP proxy, `https-proxy-agent` opens a socket to the proxy, and sends the proxy server a `CONNECT` request. If the proxy server responds with something other than a HTTP response `200`, `https-proxy-agent` incorrectly returns the socket without any TLS upgrade. This request data may contain basic auth credentials or other secrets, is sent over an unencrypted connection. A suitably positioned attacker could steal these secrets and impersonate the client.\r\n\r\n### PoC by Kris Adler\r\n\r\n```\r\nvar url = require('url');\r\nvar https = require('https');\r\nvar HttpsProxyAgent = require('https-proxy-agent');\r\n\r\nvar proxyOpts = url.parse('http://127.0.0.1:80');\r\nvar opts = url.parse('https://www.google.com');\r\nvar agent = new HttpsProxyAgent(proxyOpts);\r\nopts.agent = agent;\r\nopts.auth = 'username:password';\r\nhttps.get(opts);\r\n```\n\n## Remediation\n\nUpgrade `https-proxy-agent` to version 2.2.3 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/TooTallNate/node-https-proxy-agent/commit/36d8cf509f877fa44f4404fce57ebaf9410fe51b)\n\n- [GitHub PR](https://github.com/TooTallNate/node-https-proxy-agent/pull/77)\n\n- [HackerOne Report](https://hackerone.com/reports/541502)\n",
+      "disclosureTime": "2019-09-25T08:21:57Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "2.2.3"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-HTTPSPROXYAGENT-469131",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-300"
+        ],
+        "NSP": [
+          1184
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-10-23T09:58:05.142531Z",
+      "moduleName": "https-proxy-agent",
+      "packageManager": "npm",
+      "packageName": "https-proxy-agent",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:0",
+          "modificationTime": "2019-12-03T11:40:45.721480Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_0_20190929.patch"
+          ],
+          "version": "=2.2.1"
+        },
+        {
+          "comments": [],
+          "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:1",
+          "modificationTime": "2019-12-03T11:40:45.723464Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_1_20190929.patch"
+          ],
+          "version": "=2.2.2"
+        }
+      ],
+      "publicationTime": "2019-10-02T08:08:11Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/TooTallNate/node-https-proxy-agent/commit/36d8cf509f877fa44f4404fce57ebaf9410fe51b"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/TooTallNate/node-https-proxy-agent/pull/77"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/541502"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<2.2.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Man-in-the-Middle (MitM)",
+      "from": [
+        "goof@0.0.3",
+        "snyk@1.228.3",
+        "proxy-agent@3.1.0",
+        "https-proxy-agent@2.2.2"
+      ],
+      "upgradePath": [
+        false,
+        "snyk@1.228.3",
+        "proxy-agent@3.1.0",
+        "https-proxy-agent@2.2.3"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "https-proxy-agent",
+      "version": "2.2.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:A/AC:H/PR:N/UI:N/S:C/C:H/I:N/A:N/E:P/RL:U/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2019-09-26T10:01:07.677036Z",
+      "credit": [
+        "Kris Adler"
+      ],
+      "cvssScore": 6.1,
+      "description": "## Overview\n\n[https-proxy-agent](https://github.com/TooTallNate/node-https-proxy-agent#readme) is a module that provides an http.Agent implementation that connects to a specified HTTP or HTTPS proxy server, and can be used with the built-in https module.\n\n\nAffected versions of this package are vulnerable to Man-in-the-Middle (MitM).\nWhen targeting a HTTP proxy, `https-proxy-agent` opens a socket to the proxy, and sends the proxy server a `CONNECT` request. If the proxy server responds with something other than a HTTP response `200`, `https-proxy-agent` incorrectly returns the socket without any TLS upgrade. This request data may contain basic auth credentials or other secrets, is sent over an unencrypted connection. A suitably positioned attacker could steal these secrets and impersonate the client.\r\n\r\n### PoC by Kris Adler\r\n\r\n```\r\nvar url = require('url');\r\nvar https = require('https');\r\nvar HttpsProxyAgent = require('https-proxy-agent');\r\n\r\nvar proxyOpts = url.parse('http://127.0.0.1:80');\r\nvar opts = url.parse('https://www.google.com');\r\nvar agent = new HttpsProxyAgent(proxyOpts);\r\nopts.agent = agent;\r\nopts.auth = 'username:password';\r\nhttps.get(opts);\r\n```\n\n## Remediation\n\nUpgrade `https-proxy-agent` to version 2.2.3 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/TooTallNate/node-https-proxy-agent/commit/36d8cf509f877fa44f4404fce57ebaf9410fe51b)\n\n- [GitHub PR](https://github.com/TooTallNate/node-https-proxy-agent/pull/77)\n\n- [HackerOne Report](https://hackerone.com/reports/541502)\n",
+      "disclosureTime": "2019-09-25T08:21:57Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "2.2.3"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-HTTPSPROXYAGENT-469131",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-300"
+        ],
+        "NSP": [
+          1184
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-10-23T09:58:05.142531Z",
+      "moduleName": "https-proxy-agent",
+      "packageManager": "npm",
+      "packageName": "https-proxy-agent",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:0",
+          "modificationTime": "2019-12-03T11:40:45.721480Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_0_20190929.patch"
+          ],
+          "version": "=2.2.1"
+        },
+        {
+          "comments": [],
+          "id": "patch:SNYK-JS-HTTPSPROXYAGENT-469131:1",
+          "modificationTime": "2019-12-03T11:40:45.723464Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/https-proxy-agent/20190929/https-proxy-agent_0_1_20190929.patch"
+          ],
+          "version": "=2.2.2"
+        }
+      ],
+      "publicationTime": "2019-10-02T08:08:11Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/TooTallNate/node-https-proxy-agent/commit/36d8cf509f877fa44f4404fce57ebaf9410fe51b"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/TooTallNate/node-https-proxy-agent/pull/77"
+        },
+        {
+          "title": "HackerOne Report",
+          "url": "https://hackerone.com/reports/541502"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<2.2.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Man-in-the-Middle (MitM)",
+      "from": [
+        "goof@0.0.3",
+        "snyk@1.228.3",
+        "proxy-agent@3.1.0",
+        "pac-proxy-agent@3.0.0",
+        "https-proxy-agent@2.2.2"
+      ],
+      "upgradePath": [
+        false,
+        "snyk@1.228.3",
+        "proxy-agent@3.1.0",
+        "pac-proxy-agent@3.0.0",
+        "https-proxy-agent@2.2.3"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "https-proxy-agent",
+      "version": "2.2.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-03-11T08:25:47.093051Z",
+      "credit": [
+        "Snyk Security Team"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n\n\n## References\n\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+      "disclosureTime": "2020-03-10T08:22:24Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "0.2.1",
+        "1.2.3"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-MINIMIST-559764",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-7598"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "GHSA": [
+          "GHSA-vh95-rmgr-6w4m"
+        ],
+        "NSP": [
+          1179
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-03-18T10:21:38.800415Z",
+      "moduleName": "minimist",
+      "packageManager": "npm",
+      "packageName": "minimist",
+      "patches": [],
+      "publicationTime": "2020-03-11T08:22:19Z",
+      "references": [
+        {
+          "title": "Command Injection PoC",
+          "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+        },
+        {
+          "title": "GitHub Fix Commit #1",
+          "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+        },
+        {
+          "title": "GitHub Fix Commit #2",
+          "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+        },
+        {
+          "title": "Snyk Research Blog",
+          "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<0.2.1",
+          ">=1.0.0 <1.2.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "goof@0.0.3",
+        "npmconf@2.1.3",
+        "mkdirp@0.5.1",
+        "minimist@0.0.8"
+      ],
+      "upgradePath": [
+        false,
+        "npmconf@2.1.3",
+        "mkdirp@0.5.2",
+        "minimist@1.2.5"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "minimist",
+      "version": "0.0.8"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-03-11T08:25:47.093051Z",
+      "credit": [
+        "Snyk Security Team"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n\n\n## References\n\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+      "disclosureTime": "2020-03-10T08:22:24Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "0.2.1",
+        "1.2.3"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-MINIMIST-559764",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-7598"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "GHSA": [
+          "GHSA-vh95-rmgr-6w4m"
+        ],
+        "NSP": [
+          1179
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-03-18T10:21:38.800415Z",
+      "moduleName": "minimist",
+      "packageManager": "npm",
+      "packageName": "minimist",
+      "patches": [],
+      "publicationTime": "2020-03-11T08:22:19Z",
+      "references": [
+        {
+          "title": "Command Injection PoC",
+          "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+        },
+        {
+          "title": "GitHub Fix Commit #1",
+          "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+        },
+        {
+          "title": "GitHub Fix Commit #2",
+          "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+        },
+        {
+          "title": "Snyk Research Blog",
+          "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<0.2.1",
+          ">=1.0.0 <1.2.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "goof@0.0.3",
+        "snyk@1.228.3",
+        "update-notifier@2.5.0",
+        "latest-version@3.1.0",
+        "package-json@4.0.1",
+        "registry-auth-token@3.4.0",
+        "rc@1.2.8",
+        "minimist@1.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "snyk@1.228.3",
+        "update-notifier@2.5.0",
+        "latest-version@3.1.0",
+        "package-json@4.0.1",
+        "registry-auth-token@3.4.0",
+        "rc@1.2.8",
+        "minimist@1.2.3"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "minimist",
+      "version": "1.2.0"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-03-11T08:25:47.093051Z",
+      "credit": [
+        "Snyk Security Team"
+      ],
+      "cvssScore": 5.6,
+      "description": "## Overview\n\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n\n\n## References\n\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+      "disclosureTime": "2020-03-10T08:22:24Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "0.2.1",
+        "1.2.3"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-MINIMIST-559764",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-7598"
+        ],
+        "CWE": [
+          "CWE-400"
+        ],
+        "GHSA": [
+          "GHSA-vh95-rmgr-6w4m"
+        ],
+        "NSP": [
+          1179
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-03-18T10:21:38.800415Z",
+      "moduleName": "minimist",
+      "packageManager": "npm",
+      "packageName": "minimist",
+      "patches": [],
+      "publicationTime": "2020-03-11T08:22:19Z",
+      "references": [
+        {
+          "title": "Command Injection PoC",
+          "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+        },
+        {
+          "title": "GitHub Fix Commit #1",
+          "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+        },
+        {
+          "title": "GitHub Fix Commit #2",
+          "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+        },
+        {
+          "title": "Snyk Research Blog",
+          "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<0.2.1",
+          ">=1.0.0 <1.2.3"
+        ]
+      },
+      "severity": "medium",
+      "title": "Prototype Pollution",
+      "from": [
+        "goof@0.0.3",
+        "snyk@1.228.3",
+        "update-notifier@2.5.0",
+        "latest-version@3.1.0",
+        "package-json@4.0.1",
+        "registry-url@3.1.0",
+        "rc@1.2.8",
+        "minimist@1.2.0"
+      ],
+      "upgradePath": [
+        false,
+        "snyk@1.228.3",
+        "update-notifier@2.5.0",
+        "latest-version@3.1.0",
+        "package-json@4.0.1",
+        "registry-url@3.1.0",
+        "rc@1.2.8",
+        "minimist@1.2.3"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "minimist",
+      "version": "1.2.0"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H/E:P/RL:U/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2019-12-05T10:31:49.505060Z",
+      "credit": [
+        "mik317"
+      ],
+      "cvssScore": 7,
+      "description": "## Overview\n\n[tree-kill](https://www.npmjs.com/package/tree-kill) is a package to kill all processes in the process tree, including the root process.\n\n\nAffected versions of this package are vulnerable to Command Injection.\nUser input is concatenated with a `command` within `tree-kill` and `treekill` that will be executed without any check. \r\n\r\nNote: This vulnerability is only applicable if the package is used on a Windows operating system.\r\n\r\n### PoC by mik317 \r\n1) Create this POC file\r\n```\r\n//poc.js\r\nvar kill = require('tree-kill');\r\nkill('3333332 & echo \"HACKED\" > HACKED.txt & ');\r\n```\r\n\r\n2) Execute the following commands in another terminal:\r\n```\r\nnpm i tree-kill # Install affected module\r\ndir # Check *HACKED.txt* doesn't exist\r\nnode poc.js #  Run the PoC\r\ndir # Now *HACKED.txt* exists :)\r\n```\r\n3) A new file called `HACKED.txt` will be created, containing the `HACKED` string\n\n## Remediation\n\nUpgrade `tree-kill` to version 1.2.2 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/pkrumins/node-tree-kill/commit/ff73dbf144c4c2daa67799a50dfff59cd455c63c)\n\n- [tree-kill HackerOne Report](https://hackerone.com/reports/701183)\n\n- [treekill HackerOne Report](https://hackerone.com/reports/703415)\n\n- [Vulnerable Code treekill](https://github.com/node-modules/treekill/blob/master/index.js#L32)\n\n- [Vulnerable Code tree-kill](https://github.com/pkrumins/node-tree-kill/blob/master/index.js#L20)\n",
+      "disclosureTime": "2019-12-04T19:54:11Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "1.2.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-TREEKILL-536781",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-15598",
+          "CVE-2019-15599"
+        ],
+        "CWE": [
+          "CWE-78"
+        ],
+        "NSP": [
+          1432,
+          1433
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-12-12T13:54:40.599000Z",
+      "moduleName": "tree-kill",
+      "packageManager": "npm",
+      "packageName": "tree-kill",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:SNYK-JS-TREEKILL-536781:0",
+          "modificationTime": "2019-12-11T11:57:51.268946Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/tree-kill/20191210/tree-kill_0_0_20191210_e5d66d1fbd4b392294512d4644ac22bdc888573c.patch"
+          ],
+          "version": ">=1.0.0"
+        }
+      ],
+      "publicationTime": "2019-12-05T10:51:40Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/pkrumins/node-tree-kill/commit/ff73dbf144c4c2daa67799a50dfff59cd455c63c"
+        },
+        {
+          "title": "tree-kill HackerOne Report",
+          "url": "https://hackerone.com/reports/701183"
+        },
+        {
+          "title": "treekill HackerOne Report",
+          "url": "https://hackerone.com/reports/703415"
+        },
+        {
+          "title": "Vulnerable Code treekill",
+          "url": "https://github.com/node-modules/treekill/blob/master/index.js%23L32"
+        },
+        {
+          "title": "Vulnerable Code tree-kill",
+          "url": "https://github.com/pkrumins/node-tree-kill/blob/master/index.js%23L20"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<1.2.2"
+        ]
+      },
+      "severity": "high",
+      "title": "Command Injection",
+      "from": [
+        "goof@0.0.3",
+        "snyk@1.228.3",
+        "snyk-sbt-plugin@2.8.0",
+        "tree-kill@1.2.1"
+      ],
+      "upgradePath": [
+        false,
+        "snyk@1.228.3",
+        "snyk-sbt-plugin@2.8.0",
+        "tree-kill@1.2.2"
+      ],
+      "isUpgradable": true,
+      "isPatchable": true,
+      "name": "tree-kill",
+      "version": "1.2.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [
+        "SNYK-JS-EJS-10218"
+      ],
+      "creationTime": "2016-11-28T18:44:12.405000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cvssScore": 8.1,
+      "description": "## Overview\r\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\r\nAffected versions of the package are vulnerable to _Remote Code Execution_ by letting the attacker under certain conditions control the source folder from which the engine renders include files.\r\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\r\n\r\nThere's also a [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour. \r\n\r\n## Details\r\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\r\n\r\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\r\n```js\r\nejs.render(str, data, options);\r\n\r\nejs.renderFile(filename, data, options, callback)\r\n```\r\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\r\n```js\r\nejs.render(str, dataAndOptions);\r\n\r\nejs.renderFile(filename, dataAndOptions, callback)\r\n```\r\n\r\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `root` option, which allows changing the project root for includes with an absolute path.  \r\n\r\n```js\r\nejs.renderFile('my-template', {root:'/bad/root/'}, callback);\r\n```\r\n\r\nBy passing along the root directive in the line above, any includes would now be pulled from `/bad/root` instead of the path intended. This allows the attacker to take control of the root directory for included scripts and divert it to a library under his control, thus leading to remote code execution.\r\n\r\nThe [fix](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\r\n\r\n## Disclosure Timeline\r\n- November 27th, 2016 - Reported the issue to package owner.\r\n- November 27th, 2016 - Issue acknowledged by package owner.\r\n- November 28th, 2016 - Issue fixed and version `2.5.3` released.\r\n\r\n## Remediation\r\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\r\nOtherwise, Upgrade `ejs` to version `2.5.3` or higher.\r\n\r\n## References\r\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\r\n- [Fix commit](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6)",
+      "disclosureTime": "2016-11-27T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.5.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "ejs.js",
+            "functionName": "1.exports.render"
+          },
+          "version": [
+            "<2.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/ejs.js",
+            "functionName": "exports.render"
+          },
+          "version": [
+            "<2.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "ejs.js",
+            "functionName": "1.cpOptsInData"
+          },
+          "version": [
+            ">=2.2.1 <2.5.3"
+          ]
+        },
+        {
+          "functionId": {
+            "className": null,
+            "filePath": "lib/ejs.js",
+            "functionName": "cpOptsInData"
+          },
+          "version": [
+            ">=2.2.1 <2.5.3"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "filePath": "ejs.js",
+            "functionName": "1.exports.render"
+          },
+          "version": [
+            "<2.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/ejs.js",
+            "functionName": "exports.render"
+          },
+          "version": [
+            "<2.2.1"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "ejs.js",
+            "functionName": "1.cpOptsInData"
+          },
+          "version": [
+            ">=2.2.1 <2.5.3"
+          ]
+        },
+        {
+          "functionId": {
+            "filePath": "lib/ejs.js",
+            "functionName": "cpOptsInData"
+          },
+          "version": [
+            ">=2.2.1 <2.5.3"
+          ]
+        }
+      ],
+      "id": "npm:ejs:20161128",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-EJS-10218"
+        ],
+        "CVE": [
+          "CVE-2017-1000228"
+        ],
+        "CWE": [
+          "CWE-94"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-03-05T14:14:20.921506Z",
+      "moduleName": "ejs",
+      "packageManager": "npm",
+      "packageName": "ejs",
+      "patches": [
+        {
+          "comments": [],
+          "id": "patch:npm:ejs:20161128:0",
+          "modificationTime": "2019-12-03T11:40:45.851976Z",
+          "urls": [
+            "https://snyk-patches.s3.amazonaws.com/npm/ejs/20161128/ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+          ],
+          "version": "<2.5.3 >=2.2.4"
+        }
+      ],
+      "publicationTime": "2016-11-28T18:44:12Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6"
+        },
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<2.5.3"
+        ]
+      },
+      "severity": "high",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "goof@0.0.3",
+        "ejs-locals@1.0.2",
+        "ejs@0.8.8"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "ejs",
+      "version": "0.8.8"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+      "alternativeIds": [
+        "SNYK-JS-EJS-10225"
+      ],
+      "creationTime": "2016-11-28T18:44:12.405000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cvssScore": 5.9,
+      "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Cross-site Scripting_ by letting the attacker under certain conditions control and override the `filename` option causing it to render the value as is, without escaping it.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `filename` option, which will be rendered as is when an error occurs during rendering. \n\n```js\nejs.renderFile('my-template', {filename:'<script>alert(1)</script>'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+      "disclosureTime": "2016-11-27T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.5.5"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "npm:ejs:20161130",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-EJS-10225"
+        ],
+        "CVE": [
+          "CVE-2017-1000188"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-02-18T08:31:22.194966Z",
+      "moduleName": "ejs",
+      "packageManager": "npm",
+      "packageName": "ejs",
+      "patches": [],
+      "publicationTime": "2016-12-06T15:00:00Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+        },
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<2.5.5"
+        ]
+      },
+      "severity": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "goof@0.0.3",
+        "ejs-locals@1.0.2",
+        "ejs@0.8.8"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "ejs",
+      "version": "0.8.8"
+    },
+    {
+      "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [
+        "SNYK-JS-EJS-10226"
+      ],
+      "creationTime": "2016-11-28T18:44:12.405000Z",
+      "credit": [
+        "Snyk Security Research Team"
+      ],
+      "cvssScore": 5.9,
+      "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Denial of Service_ by letting the attacker under certain conditions control and override the `localNames` option causing it to crash.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `localNames` option, which will cause the renderer to crash.\n\n```js\nejs.renderFile('my-template', {localNames:'try'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+      "disclosureTime": "2016-11-27T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.5.5"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "npm:ejs:20161130-1",
+      "identifiers": {
+        "ALTERNATIVE": [
+          "SNYK-JS-EJS-10226"
+        ],
+        "CVE": [
+          "CVE-2017-1000189"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2019-02-18T08:31:22.206452Z",
+      "moduleName": "ejs",
+      "packageManager": "npm",
+      "packageName": "ejs",
+      "patches": [],
+      "publicationTime": "2016-12-06T15:00:00Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+        },
+        {
+          "title": "Snyk Blog",
+          "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "<2.5.5"
+        ]
+      },
+      "severity": "medium",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "goof@0.0.3",
+        "ejs-locals@1.0.2",
+        "ejs@0.8.8"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "ejs",
+      "version": "0.8.8"
+    },
+    {
+      "license": "GPL-2.0",
+      "semver": {
+        "vulnerable": [
+          ">=0"
+        ]
+      },
+      "id": "snyk:lic:npm:goof:GPL-2.0",
+      "type": "license",
+      "packageManager": "npm",
+      "language": "js",
+      "packageName": "goof",
+      "title": "GPL-2.0 license",
+      "description": "GPL-2.0 license",
+      "publicationTime": "2020-04-09T19:48:50.751Z",
+      "creationTime": "2020-04-09T19:48:50.751Z",
+      "patches": [],
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/GPL-2.0.txt",
+      "severity": "medium",
+      "from": [
+        "goof@0.0.3"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "goof",
+      "version": "0.0.3"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 418,
+  "org": "playground",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.1\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  'npm:ejs:20161128':\n    - ejs-locals > ejs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:ejs:20161130':\n    - ejs-locals > ejs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:ejs:20161130-1':\n    - ejs-locals > ejs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:hoek:20180212':\n    - tap > codecov.io > request > hawk > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n    - tap > codecov.io > request > hawk > boom > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n    - tap > codecov.io > request > hawk > sntp > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n    - tap > codecov.io > request > hawk > cryptiles > boom > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:qs:20170213':\n    - tap > codecov.io > request > qs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'snyk:lic:npm:goof:GPL-2.0':\n    - '':\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'snyk:lic:npm:symbol:MPL-2.0':\n    - tap > nyc > yargs > pkg-conf > symbol:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n# patches apply the minimum changes required to fix a vulnerability\npatch:\n  'npm:negotiator:20160616':\n    - errorhandler > accepts > negotiator:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:ms:20151024':\n    - humanize-ms > ms:\n        patched: '2019-09-23T21:21:17.183Z'\n  'npm:hawk:20160119':\n    - tap > codecov.io > request > hawk:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:http-signature:20150122':\n    - tap > codecov.io > request > http-signature:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:mime:20170907':\n    - tap > codecov.io > request > form-data > mime:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:request:20160119':\n    - tap > codecov.io > request:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:tunnel-agent:20170305':\n    - tap > codecov.io > request > tunnel-agent:\n        patched: '2019-09-23T11:31:09.532Z'\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {
+      "AGPL-1.0": "high",
+      "AGPL-3.0": "high",
+      "CDDL-1.0": "medium",
+      "CPOL-1.02": "high",
+      "GPL-2.0": "medium",
+      "LGPL-2.0": "low",
+      "LGPL-2.1": "low",
+      "LGPL-2.1+": "medium",
+      "LGPL-3.0": "low",
+      "LGPL-3.0+": "medium",
+      "MPL-1.1": "medium",
+      "MPL-2.0": "medium",
+      "MS-RL": "medium",
+      "SimPL-2.0": "high"
+    },
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": "jbvhgvg Test"
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "low",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "low",
+        "instructions": ""
+      },
+      "LGPL-2.1+": {
+        "licenseType": "LGPL-2.1+",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "low",
+        "instructions": ""
+      },
+      "LGPL-3.0+": {
+        "licenseType": "LGPL-3.0+",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "npm",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "15 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-03-07T00:18:41.509507Z",
+        "credit": [
+          "Peter van der Zee"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n\n[acorn](https://github.com/acornjs/acorn) is a tiny, fast JavaScript parser written in JavaScript.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nvia a regex in the form of `/[x-\\ud800]/u`, which causes the parser to enter an infinite loop. \r\n\r\nThis string is not a valid `UTF16` and is therefore not sanitized before reaching the parser. An application which processes untrusted input and passes it directly to `acorn`, will allow attackers to leverage the vulnerability leading to a Denial of Service.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `acorn` to version 5.7.4, 6.4.1, 7.1.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802)\n\n- [GitHub Issue 6.x Branch](https://github.com/acornjs/acorn/issues/929)\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1488)\n",
+        "disclosureTime": "2020-03-02T19:21:25Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "5.7.4",
+          "6.4.1",
+          "7.1.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-ACORN-559469",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-6chw-6frg-f759"
+          ],
+          "NSP": [
+            1488
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2020-03-10T10:19:13.616093Z",
+        "moduleName": "acorn",
+        "packageManager": "npm",
+        "packageName": "acorn",
+        "patches": [],
+        "publicationTime": "2020-03-07T00:19:23Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802"
+          },
+          {
+            "title": "GitHub Issue 6.x Branch",
+            "url": "https://github.com/acornjs/acorn/issues/929"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1488"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=5.5.0 <5.7.4",
+            ">=6.0.0 <6.4.1",
+            ">=7.0.0 <7.1.1"
+          ]
+        },
+        "severity": "high",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "from": [
+          "goof@0.0.3",
+          "@snyk/nodejs-runtime-agent@1.14.0",
+          "acorn@5.7.3"
+        ],
+        "upgradePath": [
+          false,
+          "@snyk/nodejs-runtime-agent@1.14.0",
+          "acorn@5.7.4"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "acorn",
+        "version": "5.7.3"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-03-11T08:25:47.093051Z",
+        "credit": [
+          "Snyk Security Team"
+        ],
+        "cvssScore": 5.6,
+        "description": "## Overview\n\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n\n\n## References\n\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+        "disclosureTime": "2020-03-10T08:22:24Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.2.1",
+          "1.2.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-MINIMIST-559764",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7598"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-vh95-rmgr-6w4m"
+          ],
+          "NSP": [
+            1179
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2020-03-18T10:21:38.800415Z",
+        "moduleName": "minimist",
+        "packageManager": "npm",
+        "packageName": "minimist",
+        "patches": [],
+        "publicationTime": "2020-03-11T08:22:19Z",
+        "references": [
+          {
+            "title": "Command Injection PoC",
+            "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+          },
+          {
+            "title": "GitHub Fix Commit #1",
+            "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+          },
+          {
+            "title": "GitHub Fix Commit #2",
+            "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+          },
+          {
+            "title": "Snyk Research Blog",
+            "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.2.1",
+            ">=1.0.0 <1.2.3"
+          ]
+        },
+        "severity": "medium",
+        "title": "Prototype Pollution",
+        "from": [
+          "goof@0.0.3",
+          "snyk@1.228.3",
+          "update-notifier@2.5.0",
+          "latest-version@3.1.0",
+          "package-json@4.0.1",
+          "registry-url@3.1.0",
+          "rc@1.2.8",
+          "minimist@1.2.0"
+        ],
+        "upgradePath": [
+          false,
+          "snyk@1.228.3",
+          "update-notifier@2.5.0",
+          "latest-version@3.1.0",
+          "package-json@4.0.1",
+          "registry-url@3.1.0",
+          "rc@1.2.8",
+          "minimist@1.2.3"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "minimist",
+        "version": "1.2.0"
+      },
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [
+          "SNYK-JS-EJS-10218"
+        ],
+        "creationTime": "2016-11-28T18:44:12.405000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\r\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\r\nAffected versions of the package are vulnerable to _Remote Code Execution_ by letting the attacker under certain conditions control the source folder from which the engine renders include files.\r\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\r\n\r\nThere's also a [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour. \r\n\r\n## Details\r\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\r\n\r\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\r\n```js\r\nejs.render(str, data, options);\r\n\r\nejs.renderFile(filename, data, options, callback)\r\n```\r\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\r\n```js\r\nejs.render(str, dataAndOptions);\r\n\r\nejs.renderFile(filename, dataAndOptions, callback)\r\n```\r\n\r\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `root` option, which allows changing the project root for includes with an absolute path.  \r\n\r\n```js\r\nejs.renderFile('my-template', {root:'/bad/root/'}, callback);\r\n```\r\n\r\nBy passing along the root directive in the line above, any includes would now be pulled from `/bad/root` instead of the path intended. This allows the attacker to take control of the root directory for included scripts and divert it to a library under his control, thus leading to remote code execution.\r\n\r\nThe [fix](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\r\n\r\n## Disclosure Timeline\r\n- November 27th, 2016 - Reported the issue to package owner.\r\n- November 27th, 2016 - Issue acknowledged by package owner.\r\n- November 28th, 2016 - Issue fixed and version `2.5.3` released.\r\n\r\n## Remediation\r\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\r\nOtherwise, Upgrade `ejs` to version `2.5.3` or higher.\r\n\r\n## References\r\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\r\n- [Fix commit](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6)",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.5.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "ejs.js",
+              "functionName": "1.exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "lib/ejs.js",
+              "functionName": "exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "ejs.js",
+              "functionName": "1.cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "lib/ejs.js",
+              "functionName": "cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "ejs.js",
+              "functionName": "1.exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/ejs.js",
+              "functionName": "exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "ejs.js",
+              "functionName": "1.cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/ejs.js",
+              "functionName": "cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          }
+        ],
+        "id": "npm:ejs:20161128",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EJS-10218"
+          ],
+          "CVE": [
+            "CVE-2017-1000228"
+          ],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-03-05T14:14:20.921506Z",
+        "moduleName": "ejs",
+        "packageManager": "npm",
+        "packageName": "ejs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:ejs:20161128:0",
+            "modificationTime": "2019-12-03T11:40:45.851976Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ejs/20161128/ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+            ],
+            "version": "<2.5.3 >=2.2.4"
+          }
+        ],
+        "publicationTime": "2016-11-28T18:44:12Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.5.3"
+          ]
+        },
+        "severity": "high",
+        "title": "Arbitrary Code Execution",
+        "from": [
+          "goof@0.0.3",
+          "ejs-locals@1.0.2",
+          "ejs@0.8.8"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "ejs",
+        "version": "0.8.8"
+      },
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+        "alternativeIds": [
+          "SNYK-JS-EJS-10225"
+        ],
+        "creationTime": "2016-11-28T18:44:12.405000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Cross-site Scripting_ by letting the attacker under certain conditions control and override the `filename` option causing it to render the value as is, without escaping it.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `filename` option, which will be rendered as is when an error occurs during rendering. \n\n```js\nejs.renderFile('my-template', {filename:'<script>alert(1)</script>'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.5.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:ejs:20161130",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EJS-10225"
+          ],
+          "CVE": [
+            "CVE-2017-1000188"
+          ],
+          "CWE": [
+            "CWE-79"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-02-18T08:31:22.194966Z",
+        "moduleName": "ejs",
+        "packageManager": "npm",
+        "packageName": "ejs",
+        "patches": [],
+        "publicationTime": "2016-12-06T15:00:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.5.5"
+          ]
+        },
+        "severity": "medium",
+        "title": "Cross-site Scripting (XSS)",
+        "from": [
+          "goof@0.0.3",
+          "ejs-locals@1.0.2",
+          "ejs@0.8.8"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "ejs",
+        "version": "0.8.8"
+      },
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-EJS-10226"
+        ],
+        "creationTime": "2016-11-28T18:44:12.405000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Denial of Service_ by letting the attacker under certain conditions control and override the `localNames` option causing it to crash.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `localNames` option, which will cause the renderer to crash.\n\n```js\nejs.renderFile('my-template', {localNames:'try'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.5.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:ejs:20161130-1",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EJS-10226"
+          ],
+          "CVE": [
+            "CVE-2017-1000189"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-02-18T08:31:22.206452Z",
+        "moduleName": "ejs",
+        "packageManager": "npm",
+        "packageName": "ejs",
+        "patches": [],
+        "publicationTime": "2016-12-06T15:00:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.5.5"
+          ]
+        },
+        "severity": "medium",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "goof@0.0.3",
+          "ejs-locals@1.0.2",
+          "ejs@0.8.8"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "ejs",
+        "version": "0.8.8"
+      },
+      {
+        "license": "GPL-2.0",
+        "semver": {
+          "vulnerable": [
+            ">=0"
+          ]
+        },
+        "id": "snyk:lic:npm:goof:GPL-2.0",
+        "type": "license",
+        "packageManager": "npm",
+        "language": "js",
+        "packageName": "goof",
+        "title": "GPL-2.0 license",
+        "description": "GPL-2.0 license",
+        "publicationTime": "2020-04-09T19:48:50.751Z",
+        "creationTime": "2020-04-09T19:48:50.751Z",
+        "patches": [],
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/GPL-2.0.txt",
+        "severity": "medium",
+        "from": [
+          "goof@0.0.3"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "goof",
+        "version": "0.0.3"
+      }
+    ],
+    "upgrade": {
+      "express-fileupload@0.0.5": {
+        "upgradeTo": "express-fileupload@1.1.6",
+        "upgrades": [
+          "express-fileupload@0.0.5"
+        ],
+        "vulns": [
+          "SNYK-JS-EXPRESSFILEUPLOAD-473997"
+        ]
+      },
+      "snyk@1.228.3": {
+        "upgradeTo": "snyk@1.290.1",
+        "upgrades": [
+          "dot-prop@4.2.0"
+        ],
+        "vulns": [
+          "SNYK-JS-DOTPROP-543489"
+        ]
+      }
+    },
+    "patch": {
+      "SNYK-JS-HTTPSPROXYAGENT-469131": {
+        "paths": [
+          {
+            "snyk > proxy-agent > https-proxy-agent": {
+              "patched": "2020-04-09T21:29:35.234Z"
+            }
+          },
+          {
+            "snyk > proxy-agent > pac-proxy-agent > https-proxy-agent": {
+              "patched": "2020-04-09T21:29:35.234Z"
+            }
+          }
+        ]
+      },
+      "SNYK-JS-TREEKILL-536781": {
+        "paths": [
+          {
+            "snyk > snyk-sbt-plugin > tree-kill": {
+              "patched": "2020-04-09T21:29:35.234Z"
+            }
+          }
+        ]
+      }
+    },
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": true,
+  "filtered": {
+    "ignore": [],
+    "patch": [
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-MS-10064"
+        ],
+        "creationTime": "2015-11-06T02:09:36.187000Z",
+        "credit": [
+          "Adam Baldwin"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n\n[ms](https://www.npmjs.com/package/ms) is a tiny milisecond conversion utility.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nattack when converting a time period string (i.e. `\"2 days\"`, `\"1h\"`) into a milliseconds integer. A malicious user could pass extremely long strings to `ms()`, causing the server to take a long time to process, subsequently blocking the event loop for that extended period.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `ms` to version 0.7.1 or higher.\n\n\n## References\n\n- [OSS security Advisory](https://www.openwall.com/lists/oss-security/2016/04/20/11)\n\n- [OWASP - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n- [Security Focus](https://www.securityfocus.com/bid/96389)\n",
+        "disclosureTime": "2015-10-24T20:39:59Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "0.7.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "ms.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.1.0 <=0.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.3.0 <0.7.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "ms.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.1.0 <=0.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.3.0 <0.7.1"
+            ]
+          }
+        ],
+        "id": "npm:ms:20151024",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-MS-10064"
+          ],
+          "CVE": [
+            "CVE-2015-8315"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "NSP": [
+            46
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-05-23T07:46:17.408630Z",
+        "moduleName": "ms",
+        "packageManager": "npm",
+        "packageName": "ms",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:0",
+            "modificationTime": "2019-12-03T11:40:45.772009Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_0_0_48701f029417faf65e6f5e0b61a3cebe5436b07b.patch"
+            ],
+            "version": "=0.7.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:1",
+            "modificationTime": "2019-12-03T11:40:45.773094Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch"
+            ],
+            "version": "<0.7.0 >=0.6.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:2",
+            "modificationTime": "2019-12-03T11:40:45.774221Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch"
+            ],
+            "version": "<0.6.0 >0.3.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:3",
+            "modificationTime": "2019-12-03T11:40:45.775292Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_3_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk3.patch"
+            ],
+            "version": "=0.3.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:4",
+            "modificationTime": "2019-12-03T11:40:45.776329Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_4_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk4.patch"
+            ],
+            "version": "=0.2.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:5",
+            "modificationTime": "2019-12-03T11:40:45.777474Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_5_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk5.patch"
+            ],
+            "version": "=0.1.0"
+          }
+        ],
+        "publicationTime": "2015-11-06T02:09:36Z",
+        "references": [
+          {
+            "title": "OSS security Advisory",
+            "url": "https://www.openwall.com/lists/oss-security/2016/04/20/11"
+          },
+          {
+            "title": "OWASP - ReDoS",
+            "url": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS"
+          },
+          {
+            "title": "Security Focus",
+            "url": "https://www.securityfocus.com/bid/96389"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.7.1"
+          ]
+        },
+        "severity": "medium",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "from": [
+          "goof@0.0.3",
+          "humanize-ms@1.0.1",
+          "ms@0.6.2"
+        ],
+        "upgradePath": [
+          false,
+          "humanize-ms@1.0.2",
+          "ms@0.7.1"
+        ],
+        "isUpgradable": true,
+        "isPatchable": true,
+        "name": "ms",
+        "version": "0.6.2",
+        "filtered": {
+          "patches": [
+            {
+              "patched": "2019-09-23T21:21:17.183Z",
+              "path": [
+                "humanize-ms",
+                "ms"
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "uniqueCount": 10,
+  "projectName": "goof",
+  "displayTargetFile": "package-lock.json",
+  "path": "/home/antoine/Documents/SnykSB/goof"
+}

--- a/test/fixtures/snykTestsOutputs/test-java-goof-without-more-vuln-following-upgrade.json
+++ b/test/fixtures/snykTestsOutputs/test-java-goof-without-more-vuln-following-upgrade.json
@@ -1,0 +1,9194 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2019-09-05T16:17:58.383761Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n\n[c3p0:c3p0](https://mvnrepository.com/artifact/c3p0/c3p0) is a lIbrary for augmenting traditional (DriverManager-based) JDBC drivers with JNDI-bindable DataSources, including DataSources that implement Connection and Statement Pooling, as described by the jdbc3 spec and jdbc2 std extension. Note: This library is no longer maintained and has migrated to the artifact \r\n\"com.mchange:c3p0\"\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nvia the `extractXmlConfigFromInputStream` in `com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java` during initialization.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n\n## Remediation\n\nThere is no fixed version for `c3p0:c3p0`.\n\n\n## References\n\n- [GitHub Commit](https://github.com/swaldman/c3p0/commit/7dfdda63f42759a5ec9b63d725b7412f74adb3e1)\n",
+      "disclosureTime": "2018-12-24T13:29:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [
+        {
+          "functionId": {
+            "className": "C3P0ConfigXmlUtils",
+            "filePath": "com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java",
+            "functionName": "extractXmlConfigFromInputStream"
+          },
+          "version": [
+            "[0.9.1,]"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "com.mchange.v2.c3p0.cfg.C3P0ConfigXmlUtils",
+            "functionName": "extractXmlConfigFromInputStream"
+          },
+          "version": [
+            "[0.9.1,]"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-C3P0-461017",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-20433"
+        ],
+        "CWE": [
+          "CWE-611"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "c3p0",
+        "groupId": "c3p0"
+      },
+      "modificationTime": "2020-08-09T15:01:53.772111Z",
+      "moduleName": "c3p0:c3p0",
+      "packageManager": "maven",
+      "packageName": "c3p0:c3p0",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-07-21T14:22:18Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/swaldman/c3p0/commit/7dfdda63f42759a5ec9b63d725b7412f74adb3e1"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-FINAL",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "c3p0:c3p0@0.9.1.2"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "c3p0:c3p0",
+      "version": "0.9.1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:O",
+      "alternativeIds": [],
+      "creationTime": "2019-09-05T16:24:58.914446Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.9,
+      "description": "## Overview\n[c3p0:c3p0](https://mvnrepository.com/artifact/c3p0/c3p0) is a lIbrary for augmenting traditional (DriverManager-based) JDBC drivers with JNDI-bindable DataSources, including DataSources that implement Connection and Statement Pooling, as described by the jdbc3 spec and jdbc2 std extension. Note: This library is no longer maintained and has migrated to the artifact \r\n\"com.mchange:c3p0\"\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to missing protections against recursive entity expansion when loading XML configurations.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nThere is no fixed version for `c3p0:c3p0`.\n## References\n- [Hackerone Report](https://hackerone.com/reports/509315)\n",
+      "disclosureTime": "2019-04-22T22:18:26Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [
+        {
+          "functionId": {
+            "className": "C3P0ConfigXmlUtils",
+            "filePath": "com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java",
+            "functionName": "extractXmlConfigFromInputStream"
+          },
+          "version": [
+            "[0.9.1,]"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "com.mchange.v2.c3p0.cfg.C3P0ConfigXmlUtils",
+            "functionName": "extractXmlConfigFromInputStream"
+          },
+          "version": [
+            "[0.9.1,]"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-C3P0-461018",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-5427"
+        ],
+        "CWE": [
+          "CWE-776"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "c3p0",
+        "groupId": "c3p0"
+      },
+      "modificationTime": "2020-08-09T14:59:57.018652Z",
+      "moduleName": "c3p0:c3p0",
+      "packageManager": "maven",
+      "packageName": "c3p0:c3p0",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2019-04-22T22:18:26Z",
+      "references": [
+        {
+          "title": "Hackerone Report",
+          "url": "https://hackerone.com/reports/509315"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "c3p0:c3p0@0.9.1.2"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "c3p0:c3p0",
+      "version": "0.9.1.2"
+    },
+    {
+      "license": "LGPL-3.0",
+      "semver": {
+        "vulnerable": [
+          "[0,)"
+        ]
+      },
+      "id": "snyk:lic:maven:c3p0:c3p0:LGPL-3.0",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "c3p0:c3p0",
+      "title": "LGPL-3.0 license",
+      "description": "LGPL-3.0 license",
+      "publicationTime": "2021-01-23T20:06:15.118Z",
+      "creationTime": "2021-01-23T20:06:15.118Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-3.0.txt",
+      "severity": "medium",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "c3p0:c3p0@0.9.1.2"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "c3p0:c3p0",
+      "version": "0.9.1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:56Z",
+      "credit": [
+        "TERASOLUNA Framework Development Team"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[commons-fileupload:commons-fileupload](https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload) is a component that provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). It allows remote attackers to cause a denial of service (CPU consumption) via a long boundary string.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `commons-fileupload:commons-fileupload` to version 1.3.2 or higher.\n## References\n- [Apache Mail Archive](http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E)\n- [Apache-SVN](http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h)\n- [CVE Details](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L84)\n- [GitHub Commit](https://github.com/apache/tomcat80/commit/d752a415a875e888d8c8d0988dfbde95c2c6fb1d)\n- [GitHub Commit](https://github.com/apache/tomcat/commit/2c3553f3681baf775c50bb0b49ea61cb44ea914f)\n- [GitHub Commit](https://github.com/apache/tomcat/commit/8999f8243197a5f8297d0cb1a0d86ed175678a77)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1349475)\n",
+      "disclosureTime": "2016-06-22T16:51:56Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.2"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30082",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3092"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-06-02T07:36:42.354413Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-12-25T16:51:56Z",
+      "references": [
+        {
+          "title": "Apache Mail Archive",
+          "url": "http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E"
+        },
+        {
+          "title": "Apache-SVN",
+          "url": "http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h"
+        },
+        {
+          "title": "CVE Details",
+          "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092"
+        },
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml%23L84"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/tomcat80/commit/d752a415a875e888d8c8d0988dfbde95c2c6fb1d"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/tomcat/commit/2c3553f3681baf775c50bb0b49ea61cb44ea914f"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/tomcat/commit/8999f8243197a5f8297d0cb1a0d86ed175678a77"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1349475"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.3,1.3.2)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.3.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:18.753000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nThe Apache Commons FileUpload library contains a Java Object that, upon deserialization, can be manipulated to write or copy files in arbitrary locations. If integrated with [`ysoserial`](https://github.com/frohoff/ysoserial), it is possible to upload and execute binaries in a single deserialization call.\n\n# Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n- Apache Blog\n\n## Remediation\nUpgrade `commons-fileupload` to version 1.3.3 or higher.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031)\n- [Tenable Security](http://www.tenable.com/security/research/tra-2016-12)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L65)\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c)\n",
+      "disclosureTime": "2016-10-25T14:29:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.3"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "DiskFileItem",
+            "filePath": "org/apache/commons/fileupload/disk/DiskFileItem.java",
+            "functionName": "readObject"
+          },
+          "version": [
+            "[1.1,1.3.3)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.disk.DiskFileItem",
+            "functionName": "readObject"
+          },
+          "version": [
+            "[1.1,1.3.3)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30401",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-1000031"
+        ],
+        "CWE": [
+          "CWE-284"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2019-06-02T07:36:59.369724Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-10-26T03:04:11.895000Z",
+      "references": [
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L65"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031"
+        },
+        {
+          "title": "Tenable Security",
+          "url": "http://www.tenable.com/security/research/tra-2016-12"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[1.1,1.3.3)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.3.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-10-01T08:05:48.497000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\r\n[`commons-fileupload:commons-fileupload`](https://commons.apache.org/proper/commons-fileupload/) provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\r\n\r\nAffected versions of the package are vulnerable to Information Disclosure because the `InputStream` is not closed on exception.\r\n\r\n## Remediation\r\nUpgrade `commons-fileupload` to version 1.3.2 or higher.\r\n\r\n## References\r\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L56)\r\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814)",
+      "disclosureTime": "2014-02-17T22:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.3.2"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "FileUpload",
+            "filePath": "org/apache/commons/fileupload/FileUpload.java",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[,1.0-rc1)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "FileUploadBase",
+            "filePath": "org/apache/commons/fileupload/FileUploadBase.java",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[1.0-rc1,1.2.0)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "FileUploadBase$FileItemIteratorImpl",
+            "filePath": "org/apache/commons/fileupload/FileUploadBase$FileItemIteratorImpl.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[1.2.0 ,1.3.2)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.FileUpload",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[,1.0-rc1)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.FileUploadBase",
+            "functionName": "parseRequest"
+          },
+          "version": [
+            "[1.0-rc1,1.2.0)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.apache.commons.fileupload.FileUploadBase$FileItemIteratorImpl",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[1.2.0 ,1.3.2)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-COMMONSFILEUPLOAD-31540",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-200"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "commons-fileupload",
+        "groupId": "commons-fileupload"
+      },
+      "modificationTime": "2020-06-22T17:20:16.073581Z",
+      "moduleName": "commons-fileupload:commons-fileupload",
+      "packageManager": "maven",
+      "packageName": "commons-fileupload:commons-fileupload",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-02-17T08:05:48Z",
+      "references": [
+        {
+          "title": "Github ChangeLog",
+          "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L56"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.3.2)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Information Exposure",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "commons-fileupload:commons-fileupload@1.3.1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "commons-fileupload:commons-fileupload",
+      "version": "1.3.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2019-04-10T16:07:04.634619Z",
+      "credit": [
+        "Mario Areias"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[dom4j:dom4j](https://github.com/dom4j/dom4j) is a flexible XML framework for Java. *Note*: this artifact has been deprecated for `org.dom4j:dom4j`.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection due to not validating the `QName` inputs.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `dom4j:dom4j`.\n## References\n- [GitHub Commit](https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387)\n- [GitHub Issue](https://github.com/dom4j/dom4j/issues/48)\n- [Ihacktoprotect Blog](https://ihacktoprotect.com/post/dom4j-xml-injection/)\n",
+      "disclosureTime": "2018-07-01T19:12:29Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [
+        {
+          "functionId": {
+            "className": "Namespace",
+            "filePath": "org/dom4j/Namespace.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "QName",
+            "filePath": "org/dom4j/QName.java",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.dom4j.Namespace",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.dom4j.QName",
+            "functionName": "<init>"
+          },
+          "version": [
+            "[0,]"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-DOM4J-174153",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-1000632"
+        ],
+        "CWE": [
+          "CWE-611"
+        ],
+        "GHSA": [
+          "GHSA-6pcc-3rfx-4gpm"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "dom4j",
+        "groupId": "dom4j"
+      },
+      "modificationTime": "2020-09-21T06:25:14.227405Z",
+      "moduleName": "dom4j:dom4j",
+      "packageManager": "maven",
+      "packageName": "dom4j:dom4j",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2018-08-21T14:16:13Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/dom4j/dom4j/issues/48"
+        },
+        {
+          "title": "Ihacktoprotect Blog",
+          "url": "https://ihacktoprotect.com/post/dom4j-xml-injection/"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-core@4.3.7.Final",
+        "dom4j:dom4j@1.6.1"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "dom4j:dom4j",
+      "version": "1.6.1"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:19.341000Z",
+      "credit": [
+        "David Jorm"
+      ],
+      "cvssScore": 7.3,
+      "description": "## Overview\n[javax.servlet:jstl](https://mvnrepository.com/artifact/javax.servlet/jstl) is a collection of useful JSP tags which encapsulates the core functionality common to many JSP applications.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity (XXE) attacks via a crafted XSLT extension in a `<x:parse>` or `<x:transform>` JSTL XML tag.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `javax.servlet:jstl`.\n## References\n- [Apache Mail Archive](http://mail-archives.us.apache.org/mod_mbox/www-announce/201502.mbox/%3C82207A16-6348-4DEE-877E-F7B87292576A@apache.org%3E)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254)\n- [RedHat CVE Database](https://access.redhat.com/security/cve/CVE-2015-0254)\n",
+      "disclosureTime": "2015-02-27T16:13:27Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-JAVAXSERVLET-30449",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-0254"
+        ],
+        "CWE": [
+          "CWE-94"
+        ],
+        "GHSA": [
+          "GHSA-6x4w-8w53-xrvv"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "jstl",
+        "groupId": "javax.servlet"
+      },
+      "modificationTime": "2019-04-18T07:20:47.242780Z",
+      "moduleName": "javax.servlet:jstl",
+      "packageManager": "maven",
+      "packageName": "javax.servlet:jstl",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2015-02-27T16:51:55Z",
+      "references": [
+        {
+          "title": "Apache Mail Archive",
+          "url": "http://mail-archives.us.apache.org/mod_mbox/www-announce/201502.mbox/%3C82207A16-6348-4DEE-877E-F7B87292576A@apache.org%3E"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254"
+        },
+        {
+          "title": "RedHat CVE Database",
+          "url": "https://access.redhat.com/security/cve/CVE-2015-0254"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[0,]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "javax.servlet:jstl@1.2"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "javax.servlet:jstl",
+      "version": "1.2"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:19.659000Z",
+      "credit": [
+        "Tao Wang"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[`ognl:ognl`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22ognl%22) is a simple Expression Language (EL) for Java.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks.\nApache Struts 2.0.0 through 2.3.24.1 does not properly cache method references when used with OGNL before 3.0.12, which allows remote attackers to cause a denial of service (block access to a web site) via unspecified vectors.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `ognl:ognl` to version 3.0.12 or higher.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093)\n- [GitHub Commit](https://github.com/jkuhnert/ognl/commit/ae43073fbf38db8371ff4f8bf2a966ee3b5f7e92)\n",
+      "disclosureTime": "2016-06-02T02:16:48.918000Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.0.12"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-OGNL-30474",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3093"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "ognl",
+        "groupId": "ognl"
+      },
+      "modificationTime": "2019-06-02T07:37:12.793609Z",
+      "moduleName": "ognl:ognl",
+      "packageManager": "maven",
+      "packageName": "ognl:ognl",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-02T02:16:48.918000Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/jkuhnert/ognl/commit/ae43073fbf38db8371ff4f8bf2a966ee3b5f7e92"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,3.0.12)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "ognl:ognl@3.0.6"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "ognl:ognl",
+      "version": "3.0.6"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P",
+      "alternativeIds": [],
+      "creationTime": "2020-12-08T19:30:16.810323Z",
+      "credit": [
+        "Alvaro Munoz",
+        "Masato Anzai"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE). The vulnerability exists due to improper input validation when processing certain tag's attributes. The application performs double evaluation of the code if a developer applied forced OGNL evaluation by using the `%{...}` syntax. A remote attacker can send a specially crafted request to the application and execute arbitrary code on the target system.\r\n\r\nSuccessful exploitation of this vulnerability may result in complete compromise of vulnerable system.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.26 or higher.\n## References\n- [Apache Security Advisory](https://cwiki.apache.org/confluence/display/WW/S2-061)\n- [GitHub Commit](https://github.com/apache/struts/commit/45667346629455f7ea125bff36bf9b763b7e8463)\n- [PoC](https://github.com/phil-fly/CVE-2020-17530)\n",
+      "disclosureTime": "2020-12-08T19:25:45Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "2.5.26"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-1049003",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-17530"
+        ],
+        "CWE": [
+          "CWE-94"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-12-08T19:30:16.810348Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-12-08T19:25:43Z",
+      "references": [
+        {
+          "title": "Apache Security Advisory",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-061"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/45667346629455f7ea125bff36bf9b763b7e8463"
+        },
+        {
+          "title": "PoC",
+          "url": "https://github.com/phil-fly/CVE-2020-17530"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0, 2.5.26)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Remote Code Execution (RCE)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:56Z",
+      "credit": [
+        "Viettel Information Security Center"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n`ValueStack` defines special `top` object which represents root of execution context. It can be used to manipulate Struts' internals or can be used to affect container's settings.\n\n## References\n- [Vulnerability Summary](http://struts.apache.org/docs/s2-026.html)\n",
+      "disclosureTime": "2015-07-01T16:51:56Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.24.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30060",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-5209"
+        ],
+        "CWE": [
+          "CWE-284"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2019-10-27T12:32:35.077634Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2015-07-01T16:51:56Z",
+      "references": [
+        {
+          "title": "Vulnerability Summary",
+          "url": "http://struts.apache.org/docs/s2-026.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0, 2.3.24.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Manipulation of Struts' internals",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:F/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2017-03-19T10:28:21.873000Z",
+      "credit": [
+        "Nike Zheng"
+      ],
+      "cvssScore": 10,
+      "description": "## Overview\r\n[`org.apache.struts:struts2-core`](https://cwiki.apache.org/confluence/display/WW/Home) is an elegant, extensible framework for building enterprise-ready Java web applications.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary Command Execution while uploading files with the Jakarta Multipart parser. This particular vulnerability can be exploited by an attacker by sending a crafted request to upload a file to the vulnerable server that uses a Jakarta-based plugin to process the upload request.\r\n\r\nThe attacker can then send malicious code in the `Content-Type`, `Content-Disposition` or `Content-Length` HTTP headers, which will then be executed by the vulnerable server. [A proof of concept](https://github.com/tengzhangchao/Struts2_045-Poc) that demonstrates the attack scenario is publicly available and the vulnerability is being [actively exploited in the wild](https://www.theregister.co.uk/2017/03/09/apache_under_attack_patch_for_zero_day_available/).\r\n\r\nAlthough maintainers of the open source project immediately patched the vulnerability, Struts servers that have yet to install the update remain under attack by hackers who exploit it to inject commands of their choice.\r\n\r\nThis attack can be achieved without authentication. To make matters worse, web applications don't necessarily need to successfully upload a malicious file to exploit this vulnerability, as just the presence of the vulnerable Struts library within an application is enough to exploit the vulnerability.\r\n\r\n## Remediation\r\nUpgrade `org.apache.struts:struts2-core` to version 2.3.32, 2.5.10.1 or higher.\n\n## References\n- [CVE Details](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638)\n- [Exploit DB](https://exploit-db.com/exploits/41614)\n- [Exploit DB](https://www.exploit-db.com/exploits/41570/)\n- [GitHub Commit](https://github.com/rapid7/metasploit-framework/pull/8072/commits/fc0f63e77471baa40057effaaa8be0f205adc6b7)\n- [GitHub Issue](https://github.com/rapid7/metasploit-framework/issues/8064)\n- [GitHub PR](https://github.com/rapid7/metasploit-framework/pull/8072)\n- [PoC](https://github.com/tengzhangchao/Struts2_045-Poc)\n- [Struts Wiki](https://cwiki.apache.org/confluence/display/WW/S2-045)\n- [Talos Intelligence Blog](http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html)\n",
+      "disclosureTime": "2017-03-05T22:00:00Z",
+      "exploit": "Functional",
+      "fixedIn": [
+        "2.3.32",
+        "2.5.10.1"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "JakartaMultiPartRequest",
+            "filePath": "org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java",
+            "functionName": "buildErrorMessage"
+          },
+          "version": [
+            "[2.3.5, 2.3.32)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "FileUploadInterceptor",
+            "filePath": "org/apache/struts2/interceptor/FileUploadInterceptor.java",
+            "functionName": "intercept"
+          },
+          "version": [
+            "[2.5.0, 2.5.10.1)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.apache.struts2.dispatcher.multipart.JakartaMultiPartRequest",
+            "functionName": "buildErrorMessage"
+          },
+          "version": [
+            "[2.3.5, 2.3.32)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.apache.struts2.interceptor.FileUploadInterceptor",
+            "functionName": "intercept"
+          },
+          "version": [
+            "[2.5.0, 2.5.10.1)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30207",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-5638"
+        ],
+        "CWE": [
+          "CWE-94"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-02-12T14:38:11.454392Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-03-21T15:30:44Z",
+      "references": [
+        {
+          "title": "CVE Details",
+          "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638"
+        },
+        {
+          "title": "Exploit DB",
+          "url": "https://exploit-db.com/exploits/41614"
+        },
+        {
+          "title": "Exploit DB",
+          "url": "https://www.exploit-db.com/exploits/41570/"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/rapid7/metasploit-framework/pull/8072/commits/fc0f63e77471baa40057effaaa8be0f205adc6b7"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/rapid7/metasploit-framework/issues/8064"
+        },
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/rapid7/metasploit-framework/pull/8072"
+        },
+        {
+          "title": "PoC",
+          "url": "https://github.com/tengzhangchao/Struts2_045-Poc"
+        },
+        {
+          "title": "Struts Wiki",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-045"
+        },
+        {
+          "title": "Talos Intelligence Blog",
+          "url": "http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.7, 2.3.32)",
+          "[2.5.0, 2.5.10.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.315000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 8.1,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Command Injection. When Dynamic Method Invocation was enabled, a remote attackers could execute arbitrary code via the prefix method, related to chained expressions.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/39756)\n- [GitHub Commit](https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081)\n",
+      "disclosureTime": "2016-04-22T04:32:51Z",
+      "exploit": "High",
+      "fixedIn": [
+        "2.3.20.2",
+        "2.3.24.2",
+        "2.3.28.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30770",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3081"
+        ],
+        "CWE": [
+          "CWE-77"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-06-12T14:37:05.172858Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-04-22T04:32:51Z",
+      "references": [
+        {
+          "title": "Exploit DB",
+          "url": "https://exploit-db.com/exploits/39756"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0, 2.3.20.2)",
+          "[2.3.24, 2.3.24.2)",
+          "[2.3.28, 2.3.28.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Command Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.327000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22) is a free open-source solution for creating Java web applications.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. It allows remote attackers to execute arbitrary code via the stylesheet location parameter.\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3082)",
+      "disclosureTime": "2016-04-22T02:36:52.273000Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.20.2",
+        "2.3.24.2",
+        "2.3.28.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30771",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3082"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2019-12-03T17:25:46.061028Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-04-22T02:36:52.273000Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/6bd694b7980494c12d49ca1bf39f12aec3e03e2f"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3082"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2,2.3.20.2)",
+          "[2.3.24,2.3.24.2)",
+          "[2.3.28,2.3.28.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.339000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\r\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\r\nApache Struts 2.3.20.x before 2.3.20.3, 2.3.24.x before 2.3.24.3, and 2.3.28.x before 2.3.28.1, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via vectors related to an ! (exclamation mark) operator to the REST Plugin.\r\n\r\n## References\r\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3087)",
+      "disclosureTime": "2016-06-02T00:40:36Z",
+      "exploit": "High",
+      "fixedIn": [
+        "2.3.20.2",
+        "2.3.24.3",
+        "2.3.28.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30772",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3087"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2019-07-19T13:10:41.364553Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-02T00:40:36Z",
+      "references": [
+        {
+          "title": "Exploit DB",
+          "url": "https://exploit-db.com/exploits/39919"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/6bd694b7980494c12d49ca1bf39f12aec3e03e2f"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/98d2692e434fe7f4d445ade24fe2c9860de1c13f"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3087"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2,2.3.20.2)",
+          "[2.3.24,2.3.24.3)",
+          "[2.3.28,2.3.28.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Arbitrary Command Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.353000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.1,
+      "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\nCross-site Scripting (XSS) vulnerability in the URLDecoder function in JRE before 1.8, as used in Apache Struts 2.x before 2.3.28, when using a single byte page encoding, allows remote attackers to inject arbitrary web script or HTML via multi-byte characters in a url-encoded parameter.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4003)",
+      "disclosureTime": "2016-03-16T06:52:13.014000Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.28"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30773",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4003"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2019-06-02T07:38:04.646057Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-03-16T06:52:13.014000Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/5421930b49822606792f36653b17d3d95ef106f9"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/72471d7075681bea52046645ad7aa34e9c53751e"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/a89bbe22cd2461748d595a89a254de888a415e6c"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4003"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.3.28)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.364000Z",
+      "credit": [
+        "Takeshi Terada"
+      ],
+      "cvssScore": 8.8,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Cross-site Request Forgery (CSRF). It mishandles token validation, which allows remote attackers to conduct CSRF attacks via unspecified vectors.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [Apache Struts Security Bulletin](https://struts.apache.org/docs/s2-038.html)\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4430)\n",
+      "disclosureTime": "2016-06-20T07:00:37Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.29"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30774",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4430"
+        ],
+        "CWE": [
+          "CWE-352"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-06-12T14:36:54.902858Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-20T07:00:37Z",
+      "references": [
+        {
+          "title": "Apache Struts Security Bulletin",
+          "url": "https://struts.apache.org/docs/s2-038.html"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4430"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20,2.3.29)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Cross-site Request Forgery (CSRF)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.377000Z",
+      "credit": [
+        "Takeshi Terada"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks by leveraging a default method.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [Apache Struts Security Bulletin](https://struts.apache.org/docs/s2-040.html)\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4431)\n",
+      "disclosureTime": "2016-06-21T04:49:27Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.29"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30775",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4431"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-06-12T14:37:01.532444Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-21T04:49:27Z",
+      "references": [
+        {
+          "title": "Apache Struts Security Bulletin",
+          "url": "https://struts.apache.org/docs/s2-040.html"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4431"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20,2.3.29)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Access Restriction Bypass",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.390000Z",
+      "credit": [
+        "Takeshi Terada"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks via a crafted request.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433)\n",
+      "disclosureTime": "2016-06-21T01:33:07Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.29"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30776",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4433"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-06-12T14:36:50.879545Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-21T01:33:07Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20, 2.3.29)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Access Restriction Bypass",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.415000Z",
+      "credit": [
+        "Takeshi Terada"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\nAffected versions of the package are vulnerable to Directory Traversal.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n\n\n## References\n- [Apache Security Advisory](http://struts.apache.org/docs/s2-042.html)\n",
+      "disclosureTime": "2016-10-19T01:09:09.263000Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.31"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-30778",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-6795"
+        ],
+        "CWE": [
+          "CWE-94"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2019-06-02T07:38:06.057284Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-10-19T01:09:09.263000Z",
+      "references": [
+        {
+          "title": "Apache Security Advisory",
+          "url": "http://struts.apache.org/docs/s2-042.html"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/030ffa33543f8953306ed0c0dc815c7fb74d7129"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/8e67b9144aa643769b261e2492cb561e04d016ab"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20,2.3.31)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Directory Traversal",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:O/RC:R",
+      "alternativeIds": [],
+      "creationTime": "2017-09-06T17:28:23.339000Z",
+      "credit": [
+        "LGTM Security Team"
+      ],
+      "cvssScore": 8.1,
+      "description": "## Overview\r\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\r\n\r\nThe REST Plugin in affected versions use a `XStreamHandler` with an instance of XStream for deserialization without any type filtering. By design, there are few limits to the type of objects XStream can handle. This flexibility comes at a price. The XML generated or consumed by XStream includes all information required to build Java objects of almost any type. The provided XML data is used by XStream to unmarshal Java objects. An attacker could use this flaw to execute arbitrary code or conduct further attacks.\r\n\r\n[A working exploit](https://github.com/rapid7/metasploit-framework/commit/5ea83fee5ee8c23ad95608b7e2022db5b48340ef) is publicly available and [is actively](https://www.imperva.com/blog/2017/09/cve-2017-9805-analysis-of-apache-struts-rce-vulnerability-in-rest-plugin/) exploited in the wild.\r\n\r\nYou can read more about this vulnerability [on our blog](https://snyk.io/blog/equifax-breach-vulnerable-open-source-libraries/).\r\n\r\n# Details\r\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\r\n\r\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker control the state or the flow of the execution. \r\n\r\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\r\n\r\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\r\n\r\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\r\n- Apache Blog\r\n\r\n\r\n## Remediation\r\nDevelopers are strongly advised to upgrade their _Apache Struts_ components to version `2.3.34`, `2.5.13` or higher.\r\n\r\nIt is possible that some REST actions stop working because of applied default restrictions on available classes. In this case please investigate the new interfaces that were introduced to allow class restrictions per action, those interfaces are:\r\n* org.apache.struts2.rest.handler.AllowedClasses\r\n* org.apache.struts2.rest.handler.AllowedClassNames\r\n* org.apache.struts2.rest.handler.XStreamPermissionProvider\r\n\r\nIf for some reason upgrading is not an option, consider the following workarounds:\r\n1. Disable handling XML pages and requests to such pages\r\n```xml\r\n<constant name=\"struts.action.extension\" value=\"xhtml,,json\" />\r\n```\r\n\r\n2. Override getContentType in XStreamHandler\r\n```java\r\n public class MyXStreamHandler extends XStreamHandler { \r\n   public String getContentType() {\r\n     return \"not-existing-content-type-@;/&%$#@\";\r\n   }\r\n }\r\n```\r\n\r\n3. Register the handler by overriding the one provided by the framework in your struts.xml\r\n```xml\r\n<bean type=\"org.apache.struts2.rest.handler.ContentTypeHandler\" name=\"myXStreamHandmer\" class=\"com.company.MyXStreamHandler\"/>\r\n<constant name=\"struts.rest.handlerOverride.xml\" value=\"myXStreamHandler\"/>\r\n```\r\n\r\n## References\r\n- [LGTM Advisory](https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement)\r\n- [LGTM Vulnerability Details](https://lgtm.com/blog/apache_struts_CVE-2017-9805)\r\n- [Apache Struts Statement on Equifax Security Breach](https://blogs.apache.org/foundation/entry/apache-struts-statement-on-equifax)\r\n- [Apache Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-052)",
+      "disclosureTime": "2017-09-05T17:28:23Z",
+      "exploit": "Functional",
+      "fixedIn": [
+        "2.3.34",
+        "2.5.13"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-31495",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-9805"
+        ],
+        "CWE": [
+          "CWE-20",
+          "CWE-502"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2019-07-17T13:50:20.206465Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-09-06T17:28:23Z",
+      "references": [
+        {
+          "title": "Apache Security Bulletin",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-052"
+        },
+        {
+          "title": "Apache Struts Statement on Equifax Security Breach",
+          "url": "https://blogs.apache.org/foundation/entry/apache-struts-statement-on-equifax"
+        },
+        {
+          "title": "Exploit DB",
+          "url": "https://www.exploit-db.com/exploits/42627"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/19494718865f2fb7da5ea363de3822f87fbda26"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/6dd6e5cfb7b5e020abffe7e8091bd63fe97c10a"
+        },
+        {
+          "title": "LGTM Advisory",
+          "url": "https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement"
+        },
+        {
+          "title": "LGTM Vulnerability Details",
+          "url": "https://lgtm.com/blog/apache_struts_CVE-2017-9805"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.3.34)",
+          "[2.4,2.5.13)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Arbitrary Command Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-09-12T12:47:32.905000Z",
+      "credit": [
+        "Yasser Zamani"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks.\nWhen using a Spring AOP functionality to secure Struts actions it is possible to perform a DoS attack.\n\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.33, 2.5.12 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-049.html)\n- [Struts Announcements Mailing List](https://lists.apache.org/thread.html/3795c4dd46d9ec75f4a6eb9eca11c11edd3e796c6c1fd7b17b5dc50d@%3Cannouncements.struts.apache.org%3E)\n",
+      "disclosureTime": "2017-07-13T15:29:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.33",
+        "2.5.12"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-31500",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-9787"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-04-06T16:44:43.427689Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-09-12T12:47:32.905000Z",
+      "references": [
+        {
+          "title": "Apache Security Advisory",
+          "url": "https://lists.apache.org/thread.html/3795c4dd46d9ec75f4a6eb9eca11c11edd3e796c6c1fd7b17b5dc50d@%3Cannouncements.struts.apache.org%3E"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/086b63735527d4bb0c1dd0d86a7c0374b825ff2"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/0d6442bab5b44d93c4c2e63c5335f0a331333b9"
+        },
+        {
+          "title": "Struts Security Bulletin",
+          "url": "http://struts.apache.org/docs/s2-049.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.7,2.3.33)",
+          "[2.5,2.5.12)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-09-12T12:47:32.905000Z",
+      "credit": [
+        "Adam Cazzolla",
+        "Jonathan Bullock"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks. This is due to an incomplete fix for [CVE-2017-7672](https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31499). If an application allows enter an URL in a form field and built-in URLValidator is used, it is possible to prepare a special URL which will be used to overload server process when performing validation of the URL.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.34, 2.5.13 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-050.html)\n",
+      "disclosureTime": "2017-08-23T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.34",
+        "2.5.13"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-31501",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-9804"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-04-06T16:44:43.213193Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-09-12T12:47:32.905000Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/3fddfb6eb562d597c935084e9e81d43ed6bcd02"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/418a20c0594f23764fe29ced400c1219239899a"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/744c1f409d983641af3e8e3b573c2f2d2c2c6d9"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/8a04e80f01350c90f053d71366d5e0c2186fded"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/9d47af6ffa355977b5acc713e6d1f25fac260a2"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/a05259ed69a5a48379aa91650e4cd1cb4bd6e5a"
+        },
+        {
+          "title": "Struts Security Bulletin",
+          "url": "http://struts.apache.org/docs/s2-050.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.7,2.3.34)",
+          "[2.5,2.5.13)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-09-12T12:47:32.905000Z",
+      "credit": [
+        "Huijun Chen",
+        "Xiaolong Zhu"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (ReDoS) attacks. The REST Plugin is using outdated XStream library which is vulnerable and allow perform a DoS attack using malicious request with specially crafted XML payload.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.34, 2.5.13 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-051.html)\n",
+      "disclosureTime": "2017-08-23T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.34",
+        "2.5.13"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-31502",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-9793"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-04-06T16:44:43.003236Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-09-12T12:47:32.905000Z",
+      "references": [
+        {
+          "title": "Struts Security Bulletin",
+          "url": "http://struts.apache.org/docs/s2-051.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.7,2.3.34)",
+          "[2.5,2.5.13)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F",
+      "alternativeIds": [],
+      "creationTime": "2017-09-06T17:28:23.339000Z",
+      "credit": [
+        "Lupin",
+        "David Greene",
+        "Roland McIntosh"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\r\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution. An unauthenticated attack may be able to exploit this \r\nWhen using expression literals or forcing expression in Freemarker tags (see example below) and using request values can lead to RCE attack.\r\n\r\n```xml\r\n<@s.hidden name=\"redirectUri\" value=redirectUri />\r\n<@s.hidden name=\"redirectUri\" value=\"${redirectUri}\" />\r\n<@s.hidden name=\"${redirectUri}\"/>\r\n```\r\n\r\nIn both cases a writable property is used in the value attribute and in both cases this is threatened as an expression by Freemarker. Please be aware that using Struts expression evaluation style is safe:\r\n\r\n```\r\n<@s.hidden name=\"redirectUri\" value=\"%{redirectUri}\" />\r\n<@s.hidden name=\"%{redirectUri}\"/>\r\n```\r\n\r\n## Remediation\r\nDevelopers are strongly advised to upgrade their _Apache Struts_ components to version `2.3.34`, `2.5.12` or higher.\r\n\r\n## References\r\n- [Apache Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-053)",
+      "disclosureTime": "2017-09-05T17:28:23Z",
+      "exploit": "Functional",
+      "fixedIn": [
+        "2.3.34",
+        "2.5.12"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-31503",
+      "identifiers": {
+        "CVE": [
+          "CVE-2017-12611"
+        ],
+        "CWE": [
+          "CWE-20",
+          "CWE-502"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-04-06T16:44:42.794611Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2017-09-06T17:28:23Z",
+      "references": [
+        {
+          "title": "Apache Security Bulletin",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-053"
+        },
+        {
+          "title": "Exploit",
+          "url": "https://github.com/brianwrf/S2-053-CVE-2017-12611"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/2306f5f7fad7f0157f216f34331238feb0539fa"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/637ad1c3707266c33daabb18d7754e795e6681f"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.3.34)",
+          "[2.4,2.5.12)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2018-08-22T00:00:00Z",
+      "credit": [
+        "Man Yue Mo"
+      ],
+      "cvssScore": 8.1,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution. When the namespace value is not set for a result defined in underlying xml configurations, and in same time, its upper action(s) configurations have no or wildcard namespace, an attacker may be able to conduct a remote code execution attack. They could also use the opportunity when using a url tag which does not have a value and action set and in same time, its upper action(s) configurations have no or wildcard namespace.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.35, 2.5.17 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/45367)\n- [Exploit DB](https://www.exploit-db.com/exploits/45367)\n- [GitHub Commit](https://github.com/apache/struts/commit/b3bad5ea44f3fd9edb2cb491192c5900f46d45d3)\n- [Lgtm Blog](https://lgtm.com/blog/apache_struts_CVE-2018-11776)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1620019)\n- [Struts2 Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-057)\n",
+      "disclosureTime": "2018-08-17T00:00:00Z",
+      "exploit": "High",
+      "fixedIn": [
+        "2.3.35",
+        "2.5.17"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "ActionChainResult",
+            "filePath": "com/opensymphony/xwork2/ActionChainResult.java",
+            "functionName": "execute"
+          },
+          "version": [
+            "[2.3.0, 2.3.35)",
+            "[2.5.0, 2.5.17)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "com.opensymphony.xwork2.ActionChainResult",
+            "functionName": "execute"
+          },
+          "version": [
+            "[2.3.0, 2.3.35)",
+            "[2.5.0, 2.5.17)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-32477",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-11776"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-06-12T14:37:03.442655Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2018-08-22T11:53:44Z",
+      "references": [
+        {
+          "title": "Exploit DB",
+          "url": "https://exploit-db.com/exploits/45367"
+        },
+        {
+          "title": "Exploit DB",
+          "url": "https://www.exploit-db.com/exploits/45367"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/b3bad5ea44f3fd9edb2cb491192c5900f46d45d3"
+        },
+        {
+          "title": "Lgtm Blog",
+          "url": "https://lgtm.com/blog/apache_struts_CVE-2018-11776"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1620019"
+        },
+        {
+          "title": "Struts2 Security Bulletin",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-057"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.0, 2.3.35)",
+          "[2.5.0, 2.5.17)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Remote Code Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2019-07-16T11:14:42.540198Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Improper Action Name Cleanup. It allowed attackers to have unspecified impact via vectors related to improper action name clean up.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29, 2.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/237432512df0e27013f7c7b9ab59fdce44ca34a5)\n- [GitHub Commit](https://github.com/apache/struts/commit/27ca165ddbf81c84bafbd083b99a18d89cc49ca7)\n",
+      "disclosureTime": "2016-09-19T05:25:51Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.29",
+        "2.5.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-451610",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4436"
+        ],
+        "CWE": [
+          "CWE-459"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-06-12T14:37:05.087311Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-09-19T05:25:51Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/237432512df0e27013f7c7b9ab59fdce44ca34a5"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/27ca165ddbf81c84bafbd083b99a18d89cc49ca7"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0, 2.3.29)",
+          "[2.5, 2.5.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Improper Action Name Cleanup",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "alternativeIds": [],
+      "creationTime": "2019-08-23T13:23:19.812650Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The URLValidator class allows remote attackers to cause a denial of service via a null value for a URL field.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29, 2.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152)\n- [GitHub Commit](https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465)\n",
+      "disclosureTime": "2016-06-20T07:45:43Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.29",
+        "2.5.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-460223",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4465"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-06-12T14:36:58.259938Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-20T07:45:43Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20, 2.3.29)",
+          "[2.5,2.5.1)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-08-21T14:31:35.397242Z",
+      "credit": [
+        "Matthias Kaiser"
+      ],
+      "cvssScore": 9.8,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE). Forced double OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.22 or higher.\n## References\n- [Exploit](https://www.exploit-db.com/exploits/49068)\n- [Proof Of Concept](https://github.com/PrinceFPF/CVE-2019-0230)\n- [Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-059)\n",
+      "disclosureTime": "2020-08-11T14:14:01Z",
+      "exploit": "Functional",
+      "fixedIn": [
+        "2.5.22"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-608097",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-0230"
+        ],
+        "CWE": [
+          "CWE-94"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-08-21T15:24:46.434374Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-08-21T14:06:54Z",
+      "references": [
+        {
+          "title": "Exploit",
+          "url": "https://www.exploit-db.com/exploits/49068"
+        },
+        {
+          "title": "Proof Of Concept",
+          "url": "https://github.com/PrinceFPF/CVE-2019-0230"
+        },
+        {
+          "title": "Security Bulletin",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-059"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0, 2.5.22)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "critical",
+      "title": "Remote Code Execution (RCE)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2020-08-21T14:39:32.053413Z",
+      "credit": [
+        "Takeshi Terada of Mitsui Bussan Secure Directions",
+        "Inc"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When a file upload is performed to an `Action` that exposes the file with a getter, an attacker may manipulate the request such that the working copy of the uploaded file is set to read-only. As a result, subsequent actions on the file will fail with an error. It might also be possible to set the Servlet container's temp directory to read-only, such that subsequent upload actions will fail.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.22 or higher.\n## References\n- [Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-060)\n",
+      "disclosureTime": "2020-08-11T14:36:56Z",
+      "exploit": "Proof of Concept",
+      "fixedIn": [
+        "2.5.22"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-608098",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-0233"
+        ],
+        "CWE": [
+          "CWE-400"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-08-21T15:23:58.788822Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-08-21T14:36:29Z",
+      "references": [
+        {
+          "title": "Security Bulletin",
+          "url": "https://cwiki.apache.org/confluence/display/WW/S2-060"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0, 2.5.22)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-09-04T15:56:51.451242Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 8.8,
+      "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Unrestricted Upload of File with Dangerous Type. A local code execution issue exists in Apache Struts2 when processing malformed XSLT files, which could let a malicious user upload and execute arbitrary files.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5 or higher.\n## References\n- [Bug Report](https://issues.apache.org/jira/browse/WW-5055)\n- [GitHub Commit](https://github.com/apache/struts/commit/4271682d2b944e9022e4e4c499df43e0ce7e58fd)\n",
+      "disclosureTime": "2019-12-05T15:43:54Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.5"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTS-609765",
+      "identifiers": {
+        "CVE": [
+          "CVE-2012-1592"
+        ],
+        "CWE": [
+          "CWE-434"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "struts2-core",
+        "groupId": "org.apache.struts"
+      },
+      "modificationTime": "2020-09-10T21:57:04.385281Z",
+      "moduleName": "org.apache.struts:struts2-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts:struts2-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-09-04T15:56:53Z",
+      "references": [
+        {
+          "title": "Bug Report",
+          "url": "https://issues.apache.org/jira/browse/WW-5055"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/4271682d2b944e9022e4e4c499df43e0ce7e58fd"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,2.5)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Unrestricted Upload of File with Dangerous Type",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts:struts2-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.673000Z",
+      "credit": [
+        "rskvp93"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nAffected versions of the package are vulnerable to Parameter Alteration. ValueStack defines special top object which represents root of execution context. It can be used to manipulate Struts' internals or can be used to affect container's settings\n\n\n## References\n- [Apache Security Advisory](https://struts.apache.org/docs/s2-026.html)\n",
+      "disclosureTime": "2015-09-28T16:59:30Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.24.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30798",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-5209"
+        ],
+        "CWE": [
+          "CWE-235"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2019-06-02T10:19:49.301976Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2015-09-28T16:59:30Z",
+      "references": [
+        {
+          "title": "Apache Security Advisory",
+          "url": "https://struts.apache.org/docs/s2-026.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2,2.3.24.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Parameter Alteration",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.686000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 8.8,
+      "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Improper Input Validation via a `%{}` sequence in a tag attribute, aka forced double OGNL evaluation.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.28 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/15857a69e7baf3675804495a5954cd0756ac8364)\n",
+      "disclosureTime": "2016-03-16T05:58:06Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.28"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30799",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-0785"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2020-06-12T14:36:54.876158Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-03-16T05:58:06Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/15857a69e7baf3675804495a5954cd0756ac8364"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2,2.3.28)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Improper Input Validation",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.701000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.1,
+      "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nApache Struts 2.x before 2.3.25 does not sanitize text in the Locale object constructed by I18NInterceptor, which might allow remote attackers to conduct cross-site scripting (XSS) attacks via unspecified vectors involving language display.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-2162)",
+      "disclosureTime": "2016-03-16T07:51:26.242000Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.25"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30800",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-2162"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2019-06-02T10:19:50.776439Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-03-16T07:51:26.242000Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/fc2179cf1ac9fbfb61e3430fa88b641d87253327"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-2162"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2,2.3.25)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.713000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nApache Struts 2.0.0 through 2.3.24.1 does not properly cache method references when used with OGNL before 3.0.12, which allows remote attackers to cause a denial of service (block access to a web site) via unspecified vectors.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093)",
+      "disclosureTime": "2016-06-02T02:16:48.918000Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30801",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3093"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2018-11-18T11:50:44.461613Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-02T02:16:48.918000Z",
+      "references": [
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2,2.3.24.1]"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Improper Input Validation",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.724000Z",
+      "credit": [
+        "Takeshi Terada"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks via a crafted request.\n## Remediation\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433)\n",
+      "disclosureTime": "2016-06-21T01:33:07Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30802",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4433"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2018-11-18T11:50:44.463554Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-21T01:33:07Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20,2.3.28.1]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Access Restriction Bypass",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.738000Z",
+      "credit": [
+        "Alvaro Munoz"
+      ],
+      "cvssScore": 8.8,
+      "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nAffected versions of the package are vulnerable to Remote code Execution. The Apache Struts frameworks when forced, performs double evaluation of attributes' values assigned to certain tags so it is possible to pass in a value that will be evaluated again when a tag's attributes will be rendered.\n\n## References\n- [Apache Security Advisory](https://struts.apache.org/docs/s2-036.html)\n",
+      "disclosureTime": "2016-11-14T07:48:03.440000Z",
+      "exploit": "Not Defined",
+      "fixedIn": [],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30803",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4461"
+        ],
+        "CWE": [
+          "CWE-264"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2018-11-18T11:50:44.465500Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-11-14T07:48:03.440000Z",
+      "references": [
+        {
+          "title": "Apache Security Advisory",
+          "url": "https://struts.apache.org/docs/s2-036.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.2.1,2.3.28.1]"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Arbitrary Code Execution",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:23.751000Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The URLValidator class allows remote attackers to cause a denial of service via a null value for a URL field.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.29 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152)\n- [GitHub Commit](https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465)\n",
+      "disclosureTime": "2016-06-20T07:45:43Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.29"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30804",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-4465"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2020-06-12T14:37:00.906498Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-06-20T07:45:43Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20, 2.3.29)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+      "alternativeIds": [],
+      "creationTime": "2019-07-16T11:38:49.236917Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 8.1,
+      "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Command Injection. When Dynamic Method Invocation was enabled, a remote attackers could execute arbitrary code via the prefix method, related to chained expressions.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/39756)\n- [GitHub Commit](https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081)\n",
+      "disclosureTime": "2016-04-22T04:32:51Z",
+      "exploit": "High",
+      "fixedIn": [
+        "2.3.20.2",
+        "2.3.24.2",
+        "2.3.28.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-451611",
+      "identifiers": {
+        "CVE": [
+          "CVE-2016-3081"
+        ],
+        "CWE": [
+          "CWE-77"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2020-06-12T14:37:05.096103Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-04-22T04:32:51Z",
+      "references": [
+        {
+          "title": "Exploit DB",
+          "url": "https://exploit-db.com/exploits/39756"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.0.0, 2.3.20.2)",
+          "[2.3.24, 2.3.24.2)",
+          "[2.3.28, 2.3.28.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Command Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2019-10-27T13:46:24.359760Z",
+      "credit": [
+        "Jasper Rosenberg"
+      ],
+      "cvssScore": 7.3,
+      "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Insecure Defaults. The default exclude patterns (excludeParams) allow remote attackers to \"compromise internal state of an application\" via unspecified vectors.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.20.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/5ebc0643b55d728a6713a82559a594d875452cd8)\n- [GitHub Commit](https://github.com/apache/struts/commit/d832747d647df343ed07a58b1b5e540a05a4d51b)\n- [Jira Issue](https://issues.apache.org/jira/browse/WW-4486)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1831)\n- [Struts Security Advisory](https://struts.apache.org/docs/s2-024.html)\n- [Vulnerability Summary](http://struts.apache.org/docs/s2-024.html)\n",
+      "disclosureTime": "2015-05-11T16:51:55Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "2.3.20.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-474418",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-1831"
+        ],
+        "CWE": [
+          "CWE-453"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "xwork-core",
+        "groupId": "org.apache.struts.xwork"
+      },
+      "modificationTime": "2020-06-12T14:36:54.927561Z",
+      "moduleName": "org.apache.struts.xwork:xwork-core",
+      "packageManager": "maven",
+      "packageName": "org.apache.struts.xwork:xwork-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2015-05-11T16:51:55Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/5ebc0643b55d728a6713a82559a594d875452cd8"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/apache/struts/commit/d832747d647df343ed07a58b1b5e540a05a4d51b"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://issues.apache.org/jira/browse/WW-4486"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1831"
+        },
+        {
+          "title": "Struts Security Advisory",
+          "url": "https://struts.apache.org/docs/s2-024.html"
+        },
+        {
+          "title": "Vulnerability Summary",
+          "url": "http://struts.apache.org/docs/s2-024.html"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[2.3.20,2.3.20.1)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Insecure Defaults",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.apache.struts:struts2-core@2.3.20",
+        "org.apache.struts.xwork:xwork-core@2.3.20"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.apache.struts.xwork:xwork-core",
+      "version": "2.3.20"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N/E:U/RL:O/RC:U",
+      "alternativeIds": [],
+      "creationTime": "2020-11-19T16:51:52.251545Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 8.2,
+      "description": "## Overview\n[org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) is a library providing Object/Relational Mapping (ORM) support to applications, libraries, and frameworks.\n\nAffected versions of this package are vulnerable to SQL Injection. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SQL comments of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks. The highest threat from this vulnerability is to data confidentiality and integrity.\n## Remediation\nUpgrade `org.hibernate:hibernate-core` to version 5.4.24.Final or higher.\n## References\n- [GitHub Commit](https://github.com/hibernate/hibernate-orm/commit/59fede7acaaa1579b561407aefa582311f7ebe78)\n- [Redhat CVE Details](https://access.redhat.com/security/cve/cve-2020-25638)\n",
+      "disclosureTime": "2020-11-19T16:51:45Z",
+      "exploit": "Unproven",
+      "fixedIn": [
+        "5.4.24.Final"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "SelectStatementBuilder",
+            "filePath": "org/hibernate/loader/plan/exec/query/internal/SelectStatementBuilder.java",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "Delete",
+            "filePath": "org/hibernate/sql/Delete.java",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "Insert",
+            "filePath": "org/hibernate/sql/Insert.java",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "InsertSelect",
+            "filePath": "org/hibernate/sql/InsertSelect.java",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "QuerySelect",
+            "filePath": "org/hibernate/sql/QuerySelect.java",
+            "functionName": "toQueryString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "Select",
+            "filePath": "org/hibernate/sql/Select.java",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "SimpleSelect",
+            "filePath": "org/hibernate/sql/SimpleSelect.java",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "Update",
+            "filePath": "org/hibernate/sql/Update.java",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.hibernate.loader.plan.exec.query.internal.SelectStatementBuilder",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.hibernate.sql.Delete",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.hibernate.sql.Insert",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.hibernate.sql.InsertSelect",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.hibernate.sql.QuerySelect",
+            "functionName": "toQueryString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.hibernate.sql.Select",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.hibernate.sql.SimpleSelect",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.hibernate.sql.Update",
+            "functionName": "toStatementString"
+          },
+          "version": [
+            "[,5.4.24.Final)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGHIBERNATE-1041788",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-25638"
+        ],
+        "CWE": [
+          "CWE-89"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "hibernate-core",
+        "groupId": "org.hibernate"
+      },
+      "modificationTime": "2020-12-14T08:10:39.297101Z",
+      "moduleName": "org.hibernate:hibernate-core",
+      "packageManager": "maven",
+      "packageName": "org.hibernate:hibernate-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-11-19T16:57:14.572204Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-orm/commit/59fede7acaaa1579b561407aefa582311f7ebe78"
+        },
+        {
+          "title": "Redhat CVE Details",
+          "url": "https://access.redhat.com/security/cve/cve-2020-25638"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,5.4.24.Final)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "SQL Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-core@4.3.7.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate:hibernate-core",
+      "version": "4.3.7.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-07-15T13:53:15.331818Z",
+      "credit": [
+        "Gail Badner"
+      ],
+      "cvssScore": 8.1,
+      "description": "## Overview\n[org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) is a library providing Object/Relational Mapping (ORM) support to applications, libraries, and frameworks.\n\nAffected versions of this package are vulnerable to SQL Injection. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SELECT or GROUP BY parts of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks.\n## Remediation\nUpgrade `org.hibernate:hibernate-core` to version 5.3.18.Final, 5.4.18.Final or higher.\n## References\n- [GitHub Pull Request](https://github.com/hibernate/hibernate-orm/pull/3438)\n- [Jira Ticket](https://hibernate.atlassian.net/browse/HHH-14077)\n",
+      "disclosureTime": "2020-06-18T13:46:30Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "5.3.18.Final",
+        "5.4.18.Final"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "LiteralExpression",
+            "filePath": "org/hibernate/query/criteria/internal/expression/LiteralExpression.java",
+            "functionName": "renderProjection"
+          },
+          "version": [
+            "[5.1.18.Final ,5.4.18.Final)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.hibernate.query.criteria.internal.expression.LiteralExpression",
+            "functionName": "renderProjection"
+          },
+          "version": [
+            "[5.1.18.Final ,5.4.18.Final)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGHIBERNATE-584563",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-14900"
+        ],
+        "CWE": [
+          "CWE-89"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "hibernate-core",
+        "groupId": "org.hibernate"
+      },
+      "modificationTime": "2020-08-12T13:41:12.343011Z",
+      "moduleName": "org.hibernate:hibernate-core",
+      "packageManager": "maven",
+      "packageName": "org.hibernate:hibernate-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-07-15T16:40:12Z",
+      "references": [
+        {
+          "title": "GitHub Pull Request",
+          "url": "https://github.com/hibernate/hibernate-orm/pull/3438"
+        },
+        {
+          "title": "Jira Ticket",
+          "url": "https://hibernate.atlassian.net/browse/HHH-14077"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,5.3.18.Final)",
+          "[5.4.0.Final, 5.4.18.Final)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "SQL Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-core@4.3.7.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate:hibernate-core",
+      "version": "4.3.7.Final"
+    },
+    {
+      "license": "LGPL-2.0",
+      "semver": {
+        "vulnerable": [
+          "[3.3.0.CR1, 5.3.1.Final)"
+        ]
+      },
+      "id": "snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "org.hibernate:hibernate-core",
+      "title": "LGPL-2.0 license",
+      "description": "LGPL-2.0 license",
+      "publicationTime": "2021-01-24T02:22:13.369Z",
+      "creationTime": "2021-01-24T02:22:13.369Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.0.txt",
+      "severity": "medium",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-core@4.3.7.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate:hibernate-core",
+      "version": "4.3.7.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:53Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to JSM bypass via ReflectionHelper. ReflectionHelper (`org.hibernate.validator.util.ReflectionHelper`) in Hibernate Validator 4.1.0 before 4.2.1, 4.3.x before 4.3.2, and 5.x before 5.1.2 allows attackers to bypass Java Security Manager (JSM) restrictions and execute restricted reflection calls via a crafted application.\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 4.3.2.Final, 5.1.2.Final or higher.\n## References\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/2c95d4ea0ef20977be249e31a4a4f4f4f71c945d)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/67fdff14831c035c25e098fe14bd86523d17f726)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/7e7131939a4361a7cad3e77ab89a8462132c561c)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/c489416f699a46859c134796b3ccfea41ef3ce52)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/c9525ca544b1281e2b7c7347e86e87c86dc1dc6e)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/e8c42b689df8c6752d635d02c6518da3fece3870)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/f97c2021a03c825abdeca1692f5be51e77e76a8f)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/fd4eaed7fb930db6a5e4c03742b4b3adcfecc90e)\n- [Jira Issue](https://hibernate.atlassian.net/browse/HV-912)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2014-3558)\n",
+      "disclosureTime": "2014-07-17T16:51:53Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.3.2.Final",
+        "5.1.2.Final"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGHIBERNATE-30098",
+      "identifiers": {
+        "CVE": [
+          "CVE-2014-3558"
+        ],
+        "CWE": [
+          "CWE-592"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "hibernate-validator",
+        "groupId": "org.hibernate"
+      },
+      "modificationTime": "2020-07-06T14:44:00.410984Z",
+      "moduleName": "org.hibernate:hibernate-validator",
+      "packageManager": "maven",
+      "packageName": "org.hibernate:hibernate-validator",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2014-07-17T16:51:53Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/2c95d4ea0ef20977be249e31a4a4f4f4f71c945d"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/67fdff14831c035c25e098fe14bd86523d17f726"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/7e7131939a4361a7cad3e77ab89a8462132c561c"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/c489416f699a46859c134796b3ccfea41ef3ce52"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/c9525ca544b1281e2b7c7347e86e87c86dc1dc6e"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/e8c42b689df8c6752d635d02c6518da3fece3870"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/f97c2021a03c825abdeca1692f5be51e77e76a8f"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/fd4eaed7fb930db6a5e4c03742b4b3adcfecc90e"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://hibernate.atlassian.net/browse/HV-912"
+        },
+        {
+          "title": "Redhat Bugzilla",
+          "url": "https://bugzilla.redhat.com/CVE-2014-3558"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[4.1.0.Beta1, 4.3.2.Final)",
+          "[5.0.0.Final,5.1.2.Final)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "JSM bypass via ReflectionHelper",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-validator@4.3.1.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate:hibernate-validator",
+      "version": "4.3.1.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+      "alternativeIds": [],
+      "creationTime": "2020-05-05T12:05:58.541980Z",
+      "credit": [
+        "Alvaro Muñoz"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to Improper Input Validation. A bug in the message interpolation processor enables invalid EL expressions to be evaluated as if they were valid. This flaw allows attackers to bypass input sanitation (escaping, stripping) controls that developers may have put in place when handling user-controlled data in error messages.\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 6.0.19.Final, 6.1.3.Final or higher.\n## References\n- [GitHub PR](https://github.com/hibernate/hibernate-validator/pull/1071)\n- [Jira Issue](https://hibernate.atlassian.net/browse/HV-1758)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1805501)\n",
+      "disclosureTime": "2020-05-05T00:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "6.0.19.Final",
+        "6.1.3.Final"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "ValidatorImpl",
+            "filePath": "org/hibernate/validator/internal/engine/ValidatorImpl.java",
+            "functionName": "validate"
+          },
+          "version": [
+            "[,6.0.19.Final)",
+            "[6.1.0,6.1.3.Final)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.hibernate.validator.internal.engine.ValidatorImpl",
+            "functionName": "validate"
+          },
+          "version": [
+            "[,6.0.19.Final)",
+            "[6.1.0,6.1.3.Final)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGHIBERNATE-568162",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-10693"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "hibernate-validator",
+        "groupId": "org.hibernate"
+      },
+      "modificationTime": "2020-07-06T10:04:57.507792Z",
+      "moduleName": "org.hibernate:hibernate-validator",
+      "packageManager": "maven",
+      "packageName": "org.hibernate:hibernate-validator",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-05-05T16:32:46Z",
+      "references": [
+        {
+          "title": "GitHub PR",
+          "url": "https://github.com/hibernate/hibernate-validator/pull/1071"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://hibernate.atlassian.net/browse/HV-1758"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1805501"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,6.0.19.Final)",
+          "[6.1.0,6.1.3.Final)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Improper Input Validation",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-validator@4.3.1.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate:hibernate-validator",
+      "version": "4.3.1.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N/E:U/RL:O/RC:R",
+      "alternativeIds": [],
+      "creationTime": "2020-05-14T16:07:06.897969Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 6.5,
+      "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS). The `SafeHtml` validator annotation fails to properly sanitize payloads consisting of potentially malicious code in HTML comments and instructions.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 6.0.18.Final, 6.1.0.Final or higher.\n## References\n- [Apache Security Advisory](https://lists.apache.org/thread.html/r87b7e2d22982b4ca9f88f5f4f22a19b394d2662415b233582ed22ebf@%3Cnotifications.accumulo.apache.org%3E)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/124b7dd6d9a4ad24d4d49f74701f05a13e56ceee)\n- [Hibernator Security Release Blog](https://in.relation.to/2019/11/20/hibernate-validator-610-6018-released/)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-10219)\n",
+      "disclosureTime": "2018-10-18T14:55:21Z",
+      "exploit": "Unproven",
+      "fixedIn": [
+        "6.0.18.Final",
+        "6.1.0.Final"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "SafeHtmlValidator",
+            "filePath": "org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java",
+            "functionName": "getFragmentAsDocument"
+          },
+          "version": [
+            "[,6.0.18.Final)",
+            "[6.1.0.Alpha1,6.1.0.Final)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.hibernate.validator.internal.constraintvalidators.hv.SafeHtmlValidator",
+            "functionName": "getFragmentAsDocument"
+          },
+          "version": [
+            "[,6.0.18.Final)",
+            "[6.1.0.Alpha1,6.1.0.Final)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGHIBERNATE-569100",
+      "identifiers": {
+        "CVE": [
+          "CVE-2019-10219"
+        ],
+        "CWE": [
+          "CWE-79"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "hibernate-validator",
+        "groupId": "org.hibernate"
+      },
+      "modificationTime": "2020-07-06T10:09:01.558495Z",
+      "moduleName": "org.hibernate:hibernate-validator",
+      "packageManager": "maven",
+      "packageName": "org.hibernate:hibernate-validator",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-01-09T14:55:12Z",
+      "references": [
+        {
+          "title": "Apache Security Advisory",
+          "url": "https://lists.apache.org/thread.html/r87b7e2d22982b4ca9f88f5f4f22a19b394d2662415b233582ed22ebf@%3Cnotifications.accumulo.apache.org%3E"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/hibernate/hibernate-validator/commit/124b7dd6d9a4ad24d4d49f74701f05a13e56ceee"
+        },
+        {
+          "title": "Hibernator Security Release Blog",
+          "url": "https://in.relation.to/2019/11/20/hibernate-validator-610-6018-released/"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-10219"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,6.0.18.Final)",
+          "[6.1.0.Alpha1,6.1.0.Final)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Scripting (XSS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-validator@4.3.1.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate:hibernate-validator",
+      "version": "4.3.1.Final"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-09-18T14:36:44.859594Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 8.6,
+      "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to Improper Input Validation. The protections against Reflected File Download attacks from CVE-2015-5211 may be bypassed depending on the browser used through the use of a `jsessionid` path parameter.\n## Remediation\nUpgrade `org.springframework:spring-web` to version 4.3.29.RELEASE, 5.0.19.RELEASE, 5.1.18.RELEASE, 5.2.9.RELEASE or higher.\n## References\n- [CVE-2015-5211](https://tanzu.vmware.com/security/cve-2015-5211)\n- [Pivotal Security Advisory](https://pivotal.io/security/cve-2020-5421)\n",
+      "disclosureTime": "2020-09-18T14:23:55Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "4.3.29.RELEASE",
+        "5.0.19.RELEASE",
+        "5.1.18.RELEASE",
+        "5.2.9.RELEASE"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "WebUtils",
+            "filePath": "org/springframework/web/util/WebUtils.java",
+            "functionName": "parseMatrixVariables"
+          },
+          "version": [
+            "[3.2.0.RELEASE,4.3.29.RELEASE)",
+            "[5.0.0.RELEASE, 5.0.19.RELEASE)",
+            "[5.1.0.RELEASE, 5.1.18.RELEASE)",
+            "[5.2.0.RELEASE, 5.2.9.RELEASE)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.springframework.web.util.WebUtils",
+            "functionName": "parseMatrixVariables"
+          },
+          "version": [
+            "[3.2.0.RELEASE,4.3.29.RELEASE)",
+            "[5.0.0.RELEASE, 5.0.19.RELEASE)",
+            "[5.1.0.RELEASE, 5.1.18.RELEASE)",
+            "[5.2.0.RELEASE, 5.2.9.RELEASE)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-1009832",
+      "identifiers": {
+        "CVE": [
+          "CVE-2020-5421"
+        ],
+        "CWE": [
+          "CWE-20"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "spring-web",
+        "groupId": "org.springframework"
+      },
+      "modificationTime": "2020-11-01T15:06:12.285684Z",
+      "moduleName": "org.springframework:spring-web",
+      "packageManager": "maven",
+      "packageName": "org.springframework:spring-web",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2020-09-18T16:17:53Z",
+      "references": [
+        {
+          "title": "CVE-2015-5211",
+          "url": "https://tanzu.vmware.com/security/cve-2015-5211"
+        },
+        {
+          "title": "Pivotal Security Advisory",
+          "url": "https://pivotal.io/security/cve-2020-5421"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[3.2.0.RELEASE,4.3.29.RELEASE)",
+          "[5.0.0.RELEASE, 5.0.19.RELEASE)",
+          "[5.1.0.RELEASE, 5.1.18.RELEASE)",
+          "[5.2.0.RELEASE, 5.2.9.RELEASE)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Improper Input Validation",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.springframework:spring-web@3.2.6.RELEASE"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.springframework:spring-web",
+      "version": "3.2.6.RELEASE"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:52Z",
+      "credit": [
+        "Unknown"
+      ],
+      "cvssScore": 8.8,
+      "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. This is due to not disabling the resolution of URI references by default in a DTD declaration. This occurs only when processing user provided XML documents.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `org.springframework:spring-web` to version 3.2.9.RELEASE, 4.0.5.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/8e096aeef55287dc829484996c9330cf755891a1)\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/c6503ebbf7c9e21ff022c58706dbac5417b2b5eb)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/16390)\n- [Pivotal Security](http://www.gopivotal.com/security/cve-2014-0225)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0225)\n",
+      "disclosureTime": "2016-12-25T16:51:52Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.2.9.RELEASE",
+        "4.0.5.RELEASE"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "SourceHttpMessageConverter",
+            "filePath": "org/springframework/http/converter/xml/SourceHttpMessageConverter.java",
+            "functionName": "readDOMSource"
+          },
+          "version": [
+            "[3,3.2.8.RELEASE]",
+            "[4,4.0.4.RELEASE]"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "SourceHttpMessageConverter",
+            "filePath": "org/springframework/http/converter/xml/SourceHttpMessageConverter.java",
+            "functionName": "readSAXSource"
+          },
+          "version": [
+            "[3,3.2.8.RELEASE]",
+            "[4,4.0.4.RELEASE]"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.springframework.http.converter.xml.SourceHttpMessageConverter",
+            "functionName": "readDOMSource"
+          },
+          "version": [
+            "[3,3.2.8.RELEASE]",
+            "[4,4.0.4.RELEASE]"
+          ]
+        },
+        {
+          "functionId": {
+            "className": "org.springframework.http.converter.xml.SourceHttpMessageConverter",
+            "functionName": "readSAXSource"
+          },
+          "version": [
+            "[3,3.2.8.RELEASE]",
+            "[4,4.0.4.RELEASE]"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30163",
+      "identifiers": {
+        "CVE": [
+          "CVE-2014-0225"
+        ],
+        "CWE": [
+          "CWE-611"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "spring-web",
+        "groupId": "org.springframework"
+      },
+      "modificationTime": "2020-06-12T14:37:03.352101Z",
+      "moduleName": "org.springframework:spring-web",
+      "packageManager": "maven",
+      "packageName": "org.springframework:spring-web",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-12-25T16:51:52Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/8e096aeef55287dc829484996c9330cf755891a1"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/c6503ebbf7c9e21ff022c58706dbac5417b2b5eb"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/spring-projects/spring-framework/issues/16390"
+        },
+        {
+          "title": "Pivotal Security",
+          "url": "http://www.gopivotal.com/security/cve-2014-0225"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0225"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[3.0.0.RELEASE,3.2.9.RELEASE)",
+          "[4.0.0.RELEASE,4.0.5.RELEASE)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "XML External Entity (XXE) Injection",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.springframework:spring-web@3.2.6.RELEASE"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.springframework:spring-web",
+      "version": "3.2.6.RELEASE"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:55Z",
+      "credit": [
+        "Toshiaki Maki"
+      ],
+      "cvssScore": 5.5,
+      "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). It does not properly process inline DTD declarations when DTD is not entirely disabled, which allows remote attackers to cause a denial of service (memory consumption and out-of-memory errors) via a crafted XML file.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `org.springframework:spring-web` to version 3.2.14.RELEASE, 4.1.7.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/5a711c05ec750f069235597173084c2ee796242)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/17727)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3192)\n- [Pivotal Security](http://pivotal.io/security/cve-2015-3192)\n",
+      "disclosureTime": "2015-10-16T05:57:41Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.2.14.RELEASE",
+        "4.1.7.RELEASE"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30164",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-3192"
+        ],
+        "CWE": [
+          "CWE-119"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "spring-web",
+        "groupId": "org.springframework"
+      },
+      "modificationTime": "2020-06-12T14:36:56.172880Z",
+      "moduleName": "org.springframework:spring-web",
+      "packageManager": "maven",
+      "packageName": "org.springframework:spring-web",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-12-25T16:51:55Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/5a711c05ec750f069235597173084c2ee796242"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/spring-projects/spring-framework/issues/17727"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3192"
+        },
+        {
+          "title": "Pivotal Security",
+          "url": "http://pivotal.io/security/cve-2015-3192"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[3.2.0.RELEASE, 3.2.14.RELEASE)",
+          "[4.0.0.RELEASE, 4.1.7.RELEASE)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Denial of Service (DoS)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.springframework:spring-web@3.2.6.RELEASE"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.springframework:spring-web",
+      "version": "3.2.6.RELEASE"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+      "alternativeIds": [],
+      "creationTime": "2016-12-25T16:51:56Z",
+      "credit": [
+        "Alvaro Muñoz"
+      ],
+      "cvssScore": 8.6,
+      "description": "## Overview\n\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\n\nAffected versions of this package are vulnerable to Reflected File Download\nvia a crafted URL with a batch script extension, resulting in the response being downloaded rather than rendered.\n\n## Remediation\n\nUpgrade `org.springframework:spring-web` to version 3.2.15.RELEASE, 4.1.8.RELEASE, 4.2.2.RELEASE or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/03f547eb9868f48f44d59b56067d4ac4740672c3)\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/2bd1daa75ee0b8ec33608ca6ab065ef3e1815543)\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/a95c3d820dbc4c3ae752f1b3ee22ee860b162402)\n\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/18124)\n\n- [Oren Hafif Blog](https://www.trustwave.com/Resources/SpiderLabs-Blog/Reflected-File-Download---A-New-Web-Attack-Vector/)\n\n- [Pivotal Security](http://pivotal.io/security/cve-2015-5211)\n\n- [RedHat CVE Database](https://access.redhat.com/security/cve/cve-2015-5211)\n",
+      "disclosureTime": "2015-10-15T16:51:56Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.2.15.RELEASE",
+        "4.1.8.RELEASE",
+        "4.2.2.RELEASE"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30165",
+      "identifiers": {
+        "CVE": [
+          "CVE-2015-5211"
+        ],
+        "CWE": [
+          "CWE-494"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "spring-web",
+        "groupId": "org.springframework"
+      },
+      "modificationTime": "2019-09-19T11:19:29.640092Z",
+      "moduleName": "org.springframework:spring-web",
+      "packageManager": "maven",
+      "packageName": "org.springframework:spring-web",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2016-12-25T16:51:56Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/03f547eb9868f48f44d59b56067d4ac4740672c3"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/2bd1daa75ee0b8ec33608ca6ab065ef3e1815543"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/a95c3d820dbc4c3ae752f1b3ee22ee860b162402"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/spring-projects/spring-framework/issues/18124"
+        },
+        {
+          "title": "Oren Hafif Blog",
+          "url": "https://www.trustwave.com/Resources/SpiderLabs-Blog/Reflected-File-Download---A-New-Web-Attack-Vector/"
+        },
+        {
+          "title": "Pivotal Security",
+          "url": "http://pivotal.io/security/cve-2015-5211"
+        },
+        {
+          "title": "RedHat CVE Database",
+          "url": "https://access.redhat.com/security/cve/cve-2015-5211"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[3.2.0.RELEASE, 3.2.15.RELEASE)",
+          "[4.0.0.RELEASE, 4.1.8.RELEASE)",
+          "[4.2.0.RELEASE, 4.2.2.RELEASE)"
+        ]
+      },
+      "severity": "high",
+      "severityWithCritical": "high",
+      "title": "Reflected File Download",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.springframework:spring-web@3.2.6.RELEASE"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.springframework:spring-web",
+      "version": "3.2.6.RELEASE"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:L",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:31.538000Z",
+      "credit": [
+        "Spase Markovski"
+      ],
+      "cvssScore": 6.3,
+      "description": "## Overview\r\n[`org.springframework:spring-web`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22spring-web%22)\r\nAffected versions of this package do not disable external entity resolution, which allows remote attackers to read arbitrary files, cause a denial of service and conduct CSRF attacks via crafted XML, aka an XML External Entity (XXE) issue.  \r\n\r\n**NOTE:** this vulnerability exists because of an incomplete fix for [CVE-2013-4152](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31330), [CVE-2013-7315](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30162), and [CVE-2013-6429](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30160).\r\n\r\n## References\r\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0054)",
+      "disclosureTime": "2014-04-17T14:55:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.2.8.RELEASE",
+        "4.0.2.RELEASE"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-31331",
+      "identifiers": {
+        "CVE": [
+          "CVE-2014-0054"
+        ],
+        "CWE": [
+          "CWE-352"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "spring-web",
+        "groupId": "org.springframework"
+      },
+      "modificationTime": "2019-09-16T14:38:30.980318Z",
+      "moduleName": "org.springframework:spring-web",
+      "packageManager": "maven",
+      "packageName": "org.springframework:spring-web",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2014-06-06T21:43:43Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/edba32b3093703d5e9ed42b5b8ec23ecc1998398%23diff-1f3f1d5cdab9ac92d1ca5ec7def8f131"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/fb0683c066e74e9667d6cd8c5fa01f674c68c3be%23diff-1f3f1d5cdab9ac92d1ca5ec7def8f131"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://jira.spring.io/browse/SPR-11376"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0054"
+        },
+        {
+          "title": "Pivotal Security",
+          "url": "http://www.pivotal.io/security/cve-2014-0054"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[3.0.0.RELEASE,3.2.8.RELEASE)",
+          "[4.0.0.RELEASE,4.0.2.RELEASE)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Cross-site Request Forgery (CSRF)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.springframework:spring-web@3.2.6.RELEASE"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.springframework:spring-web",
+      "version": "3.2.6.RELEASE"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+      "alternativeIds": [],
+      "creationTime": "2017-02-22T07:28:31.465000Z",
+      "credit": [
+        "Takeshi Terada"
+      ],
+      "cvssScore": 5.3,
+      "description": "## Overview\n[org.springframework:spring-core](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22spring-core%22) is a core package within the spring-framework that contains multiple classes and utilities.\n\nAffected versions of this package are vulnerable to Directory Traversal. It allows remote attackers to read arbitrary files via a crafted URL.\n\n## Details\n\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\n\nDirectory Traversal vulnerabilities can be generally divided into two types:\n\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\n\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\n\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\n\n```\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\n```\n**Note** `%2e` is the URL encoded version of `.` (dot).\n\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \n\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\n\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\n\n```\n2018-04-15 22:04:29 .....           19           19  good.txt\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\n```\n\n## Remediation\nUpgrade `org.springframework:spring-core` to version 3.2.9.RELEASE, 4.0.5.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/e3e71ba92a8b82dadf474eda76cd2741f65a77a8)\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/f6fddeb6eb7da625fd711ab371ff16512f431e8d)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/16414)\n- [Jira Issue](https://jira.spring.io/browse/SPR-12354)\n- [JVNDB](http://jvndb.jvn.jp/en/contents/2014/JVNDB-2014-000054.html)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3578)\n- [Pivotal Security](https://pivotal.io/security/cve-2014-3578)\n- [Pivotal Security](http://www.pivotal.io/security/cve-2014-3578)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1131882)\n",
+      "disclosureTime": "2014-09-05T17:16:58Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "3.2.9.RELEASE",
+        "4.0.5.RELEASE"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-31325",
+      "identifiers": {
+        "CVE": [
+          "CVE-2014-3578"
+        ],
+        "CWE": [
+          "CWE-22"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "spring-core",
+        "groupId": "org.springframework"
+      },
+      "modificationTime": "2020-06-12T14:37:03.069547Z",
+      "moduleName": "org.springframework:spring-core",
+      "packageManager": "maven",
+      "packageName": "org.springframework:spring-core",
+      "patches": [],
+      "proprietary": false,
+      "publicationTime": "2014-09-05T17:16:58Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/e3e71ba92a8b82dadf474eda76cd2741f65a77a8"
+        },
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/spring-projects/spring-framework/commit/f6fddeb6eb7da625fd711ab371ff16512f431e8d"
+        },
+        {
+          "title": "GitHub Issue",
+          "url": "https://github.com/spring-projects/spring-framework/issues/16414"
+        },
+        {
+          "title": "Jira Issue",
+          "url": "https://jira.spring.io/browse/SPR-12354"
+        },
+        {
+          "title": "JVNDB",
+          "url": "http://jvndb.jvn.jp/en/contents/2014/JVNDB-2014-000054.html"
+        },
+        {
+          "title": "NVD",
+          "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3578"
+        },
+        {
+          "title": "Pivotal Security",
+          "url": "https://pivotal.io/security/cve-2014-3578"
+        },
+        {
+          "title": "Pivotal Security",
+          "url": "http://www.pivotal.io/security/cve-2014-3578"
+        },
+        {
+          "title": "RedHat Bugzilla Bug",
+          "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1131882"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[3.0.0.RELEASE, 3.2.9.RELEASE)",
+          "[4.0.0.RELEASE, 4.0.5.RELEASE)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Directory Traversal",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.springframework:spring-web@3.2.6.RELEASE",
+        "org.springframework:spring-core@3.2.6.RELEASE"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.springframework:spring-core",
+      "version": "3.2.6.RELEASE"
+    },
+    {
+      "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+      "alternativeIds": [],
+      "creationTime": "2018-05-30T12:32:02.349000Z",
+      "credit": [
+        "Snyk Security research Team"
+      ],
+      "cvssScore": 5.5,
+      "description": "## Overview\r\n[`org.zeroturnaround:zt-zip`](https://github.com/zeroturnaround/zt-zip) is a library that helps to create, modify or extract ZIP archives.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip Slip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n\r\n## Vulnerable Method\r\nThis vulnerability appears in method `process` under class name `Unpacker` in `org/zeroturnaround/zip/ZipUtil.java` [[1]](https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff)\r\n\r\n\r\n## Remediation\r\nUpgrade `org.zeroturnaround:zt-zip` to version 1.13 or higher.\n\n## References\n- [GitHub Commit](https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff)\n- [Zip Slip Advisory](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+      "disclosureTime": "2018-04-17T21:00:00Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "1.13"
+      ],
+      "functions": [
+        {
+          "functionId": {
+            "className": "ZipUtil$Unpacker",
+            "filePath": "org/zeroturnaround/zip/ZipUtil$Unpacker.java",
+            "functionName": "process"
+          },
+          "version": [
+            "[,1.13)"
+          ]
+        }
+      ],
+      "functions_new": [
+        {
+          "functionId": {
+            "className": "org.zeroturnaround.zip.ZipUtil$Unpacker",
+            "functionName": "process"
+          },
+          "version": [
+            "[,1.13)"
+          ]
+        }
+      ],
+      "id": "SNYK-JAVA-ORGZEROTURNAROUND-31681",
+      "identifiers": {
+        "CVE": [
+          "CVE-2018-1002201"
+        ],
+        "CWE": [
+          "CWE-29"
+        ]
+      },
+      "language": "java",
+      "mavenModuleName": {
+        "artifactId": "zt-zip",
+        "groupId": "org.zeroturnaround"
+      },
+      "modificationTime": "2020-06-09T09:57:45.874102Z",
+      "moduleName": "org.zeroturnaround:zt-zip",
+      "packageManager": "maven",
+      "packageName": "org.zeroturnaround:zt-zip",
+      "patches": [],
+      "proprietary": true,
+      "publicationTime": "2018-05-31T07:32:02Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff"
+        },
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://github.com/snyk/zip-slip-vulnerability"
+        },
+        {
+          "title": "Zip Slip Advisory",
+          "url": "https://snyk.io/research/zip-slip-vulnerability"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          "[,1.13)"
+        ]
+      },
+      "severity": "medium",
+      "severityWithCritical": "medium",
+      "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "org.zeroturnaround:zt-zip@1.12"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.zeroturnaround:zt-zip",
+      "version": "1.12"
+    },
+    {
+      "license": "EPL-1.0",
+      "semver": {
+        "vulnerable": [
+          "[0,)"
+        ]
+      },
+      "id": "snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "org.aspectj:aspectjweaver",
+      "title": "EPL-1.0 license",
+      "description": "EPL-1.0 license",
+      "publicationTime": "2021-01-24T06:09:00.675Z",
+      "creationTime": "2021-01-24T06:09:00.675Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/EPL-1.0.txt",
+      "severity": "medium",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.aspectj:aspectjweaver@1.8.2"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.aspectj:aspectjweaver",
+      "version": "1.8.2"
+    },
+    {
+      "license": "LGPL-2.1",
+      "semver": {
+        "vulnerable": [
+          "[0,)"
+        ]
+      },
+      "id": "snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "org.hibernate.common:hibernate-commons-annotations",
+      "title": "LGPL-2.1 license",
+      "description": "LGPL-2.1 license",
+      "publicationTime": "2021-01-23T13:15:50.440Z",
+      "creationTime": "2021-01-23T13:15:50.440Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.1.txt",
+      "severity": "medium",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-core@4.3.7.Final",
+        "org.hibernate.common:hibernate-commons-annotations@4.0.5.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate.common:hibernate-commons-annotations",
+      "version": "4.0.5.Final"
+    },
+    {
+      "license": "EPL-1.0",
+      "semver": {
+        "vulnerable": [
+          "[0,)"
+        ]
+      },
+      "id": "snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "org.hibernate.javax.persistence:hibernate-jpa-2.1-api",
+      "title": "EPL-1.0 license",
+      "description": "EPL-1.0 license",
+      "publicationTime": "2021-01-23T15:03:54.053Z",
+      "creationTime": "2021-01-23T15:03:54.053Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/EPL-1.0.txt",
+      "severity": "medium",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-core@4.3.7.Final",
+        "org.hibernate.javax.persistence:hibernate-jpa-2.1-api@1.0.0.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate.javax.persistence:hibernate-jpa-2.1-api",
+      "version": "1.0.0.Final"
+    },
+    {
+      "license": "LGPL-2.0",
+      "semver": {
+        "vulnerable": [
+          "[3.5.0.Beta-1, 5.3.1.Final)"
+        ]
+      },
+      "id": "snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "org.hibernate:hibernate-entitymanager",
+      "title": "LGPL-2.0 license",
+      "description": "LGPL-2.0 license",
+      "publicationTime": "2021-01-23T14:41:41.088Z",
+      "creationTime": "2021-01-23T14:41:41.088Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.0.txt",
+      "severity": "medium",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-entitymanager@4.3.7.Final"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.hibernate:hibernate-entitymanager",
+      "version": "4.3.7.Final"
+    },
+    {
+      "license": "LGPL-2.1",
+      "semver": {
+        "vulnerable": [
+          "[3.0.1.GA, 3.1.2.GA)"
+        ]
+      },
+      "id": "snyk:lic:maven:org.jboss.logging:jboss-logging:LGPL-2.1",
+      "type": "license",
+      "packageManager": "maven",
+      "language": "java",
+      "packageName": "org.jboss.logging:jboss-logging",
+      "title": "LGPL-2.1 license",
+      "description": "LGPL-2.1 license",
+      "publicationTime": "2021-01-23T20:25:24.879Z",
+      "creationTime": "2021-01-23T20:25:24.879Z",
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.1.txt",
+      "severity": "medium",
+      "from": [
+        "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+        "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+        "org.hibernate:hibernate-validator@4.3.1.Final",
+        "org.jboss.logging:jboss-logging@3.1.0.CR2"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "org.jboss.logging:jboss-logging",
+      "version": "3.1.0.CR2"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 53,
+  "org": "playground",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "Artistic-1.0": {
+        "licenseType": "Artistic-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "Artistic-2.0": {
+        "licenseType": "Artistic-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "EPL-1.0": {
+        "licenseType": "EPL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-3.0": {
+        "licenseType": "GPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "maven",
+  "projectId": "37a29fe9-c342-4d70-8efc-df96a8d730b3",
+  "ignoreSettings": null,
+  "summary": "58 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-09-05T16:17:58.383761Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n\n[c3p0:c3p0](https://mvnrepository.com/artifact/c3p0/c3p0) is a lIbrary for augmenting traditional (DriverManager-based) JDBC drivers with JNDI-bindable DataSources, including DataSources that implement Connection and Statement Pooling, as described by the jdbc3 spec and jdbc2 std extension. Note: This library is no longer maintained and has migrated to the artifact \r\n\"com.mchange:c3p0\"\n\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection.\nvia the `extractXmlConfigFromInputStream` in `com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java` during initialization.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\r\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\r\n\r\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\r\n\r\nFor example, below is a sample XML document, containing an XML element- username.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n   <username>John</username>\r\n</xml>\r\n```\r\n\r\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\r\n\r\n```xml\r\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\r\n<!DOCTYPE foo [\r\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\r\n   <username>&xxe;</username>\r\n</xml>\r\n```\r\n\r\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n\n## Remediation\n\nThere is no fixed version for `c3p0:c3p0`.\n\n\n## References\n\n- [GitHub Commit](https://github.com/swaldman/c3p0/commit/7dfdda63f42759a5ec9b63d725b7412f74adb3e1)\n",
+        "disclosureTime": "2018-12-24T13:29:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [
+          {
+            "functionId": {
+              "className": "C3P0ConfigXmlUtils",
+              "filePath": "com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java",
+              "functionName": "extractXmlConfigFromInputStream"
+            },
+            "version": [
+              "[0.9.1,]"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.mchange.v2.c3p0.cfg.C3P0ConfigXmlUtils",
+              "functionName": "extractXmlConfigFromInputStream"
+            },
+            "version": [
+              "[0.9.1,]"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-C3P0-461017",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-20433"
+          ],
+          "CWE": [
+            "CWE-611"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "c3p0",
+          "groupId": "c3p0"
+        },
+        "modificationTime": "2020-08-09T15:01:53.772111Z",
+        "moduleName": "c3p0:c3p0",
+        "packageManager": "maven",
+        "packageName": "c3p0:c3p0",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-07-21T14:22:18Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/swaldman/c3p0/commit/7dfdda63f42759a5ec9b63d725b7412f74adb3e1"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "c3p0:c3p0@0.9.1.2"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "c3p0:c3p0",
+        "version": "0.9.1.2"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H/RL:O",
+        "alternativeIds": [],
+        "creationTime": "2019-09-05T16:24:58.914446Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[c3p0:c3p0](https://mvnrepository.com/artifact/c3p0/c3p0) is a lIbrary for augmenting traditional (DriverManager-based) JDBC drivers with JNDI-bindable DataSources, including DataSources that implement Connection and Statement Pooling, as described by the jdbc3 spec and jdbc2 std extension. Note: This library is no longer maintained and has migrated to the artifact \r\n\"com.mchange:c3p0\"\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to missing protections against recursive entity expansion when loading XML configurations.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nThere is no fixed version for `c3p0:c3p0`.\n## References\n- [Hackerone Report](https://hackerone.com/reports/509315)\n",
+        "disclosureTime": "2019-04-22T22:18:26Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [
+          {
+            "functionId": {
+              "className": "C3P0ConfigXmlUtils",
+              "filePath": "com/mchange/v2/c3p0/cfg/C3P0ConfigXmlUtils.java",
+              "functionName": "extractXmlConfigFromInputStream"
+            },
+            "version": [
+              "[0.9.1,]"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.mchange.v2.c3p0.cfg.C3P0ConfigXmlUtils",
+              "functionName": "extractXmlConfigFromInputStream"
+            },
+            "version": [
+              "[0.9.1,]"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-C3P0-461018",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-5427"
+          ],
+          "CWE": [
+            "CWE-776"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "c3p0",
+          "groupId": "c3p0"
+        },
+        "modificationTime": "2020-08-09T14:59:57.018652Z",
+        "moduleName": "c3p0:c3p0",
+        "packageManager": "maven",
+        "packageName": "c3p0:c3p0",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2019-04-22T22:18:26Z",
+        "references": [
+          {
+            "title": "Hackerone Report",
+            "url": "https://hackerone.com/reports/509315"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "c3p0:c3p0@0.9.1.2"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "c3p0:c3p0",
+        "version": "0.9.1.2"
+      },
+      {
+        "license": "LGPL-3.0",
+        "semver": {
+          "vulnerable": [
+            "[0,)"
+          ]
+        },
+        "id": "snyk:lic:maven:c3p0:c3p0:LGPL-3.0",
+        "type": "license",
+        "packageManager": "maven",
+        "language": "java",
+        "packageName": "c3p0:c3p0",
+        "title": "LGPL-3.0 license",
+        "description": "LGPL-3.0 license",
+        "publicationTime": "2021-01-23T20:06:15.118Z",
+        "creationTime": "2021-01-23T20:06:15.118Z",
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-3.0.txt",
+        "severity": "medium",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "c3p0:c3p0@0.9.1.2"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "c3p0:c3p0",
+        "version": "0.9.1.2"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:56Z",
+        "credit": [
+          "TERASOLUNA Framework Development Team"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[commons-fileupload:commons-fileupload](https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload) is a component that provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). It allows remote attackers to cause a denial of service (CPU consumption) via a long boundary string.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `commons-fileupload:commons-fileupload` to version 1.3.2 or higher.\n## References\n- [Apache Mail Archive](http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E)\n- [Apache-SVN](http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h)\n- [CVE Details](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml#L84)\n- [GitHub Commit](https://github.com/apache/tomcat80/commit/d752a415a875e888d8c8d0988dfbde95c2c6fb1d)\n- [GitHub Commit](https://github.com/apache/tomcat/commit/2c3553f3681baf775c50bb0b49ea61cb44ea914f)\n- [GitHub Commit](https://github.com/apache/tomcat/commit/8999f8243197a5f8297d0cb1a0d86ed175678a77)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1349475)\n",
+        "disclosureTime": "2016-06-22T16:51:56Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.3.2"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30082",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-3092"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "commons-fileupload",
+          "groupId": "commons-fileupload"
+        },
+        "modificationTime": "2019-06-02T07:36:42.354413Z",
+        "moduleName": "commons-fileupload:commons-fileupload",
+        "packageManager": "maven",
+        "packageName": "commons-fileupload:commons-fileupload",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-12-25T16:51:56Z",
+        "references": [
+          {
+            "title": "Apache Mail Archive",
+            "url": "http://mail-archives.us.apache.org/mod_mbox/www-announce/201606.mbox/%3C6223ece6-2b41-ef4f-22f9-d3481e492832@apache.org%3E"
+          },
+          {
+            "title": "Apache-SVN",
+            "url": "http://svn.apache.org/viewvc/commons/proper/fileupload/trunk/RELEASE-NOTES.txt?r1=1745717&r2=1749637&diff_format=h"
+          },
+          {
+            "title": "CVE Details",
+            "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-3092"
+          },
+          {
+            "title": "Github ChangeLog",
+            "url": "https://github.com/apache/commons-fileupload/blob/b1498c9877d751f8bc4635a6f252ebdfcba28518/src/changes/changes.xml%23L84"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/tomcat80/commit/d752a415a875e888d8c8d0988dfbde95c2c6fb1d"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/tomcat/commit/2c3553f3681baf775c50bb0b49ea61cb44ea914f"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/tomcat/commit/8999f8243197a5f8297d0cb1a0d86ed175678a77"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1349475"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[1.3,1.3.2)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "commons-fileupload:commons-fileupload@1.3.1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "commons-fileupload:commons-fileupload",
+        "version": "1.3.1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:18.753000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[`commons-fileupload:commons-fileupload`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22commons-fileupload%22)\nThe Apache Commons FileUpload library contains a Java Object that, upon deserialization, can be manipulated to write or copy files in arbitrary locations. If integrated with [`ysoserial`](https://github.com/frohoff/ysoserial), it is possible to upload and execute binaries in a single deserialization call.\n\n# Details\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\n\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker to control the state or the flow of the execution.\n\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\n\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\n\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\n- Apache Blog\n\n## Remediation\nUpgrade `commons-fileupload` to version 1.3.3 or higher.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031)\n- [Tenable Security](http://www.tenable.com/security/research/tra-2016-12)\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L65)\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c)\n",
+        "disclosureTime": "2016-10-25T14:29:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.3.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "DiskFileItem",
+              "filePath": "org/apache/commons/fileupload/disk/DiskFileItem.java",
+              "functionName": "readObject"
+            },
+            "version": [
+              "[1.1,1.3.3)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.apache.commons.fileupload.disk.DiskFileItem",
+              "functionName": "readObject"
+            },
+            "version": [
+              "[1.1,1.3.3)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMMONSFILEUPLOAD-30401",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-1000031"
+          ],
+          "CWE": [
+            "CWE-284"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "commons-fileupload",
+          "groupId": "commons-fileupload"
+        },
+        "modificationTime": "2019-06-02T07:36:59.369724Z",
+        "moduleName": "commons-fileupload:commons-fileupload",
+        "packageManager": "maven",
+        "packageName": "commons-fileupload:commons-fileupload",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-10-26T03:04:11.895000Z",
+        "references": [
+          {
+            "title": "Github ChangeLog",
+            "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L65"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/commons-fileupload/commit/388e824518697c2c8f9f83fd964621d9c2f8fc4c"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-1000031"
+          },
+          {
+            "title": "Tenable Security",
+            "url": "http://www.tenable.com/security/research/tra-2016-12"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[1.1,1.3.3)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Arbitrary Code Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "commons-fileupload:commons-fileupload@1.3.1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "commons-fileupload:commons-fileupload",
+        "version": "1.3.1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-10-01T08:05:48.497000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 6.5,
+        "description": "## Overview\r\n[`commons-fileupload:commons-fileupload`](https://commons.apache.org/proper/commons-fileupload/) provides a simple yet flexible means of adding support for multipart file upload functionality to servlets and web applications.\r\n\r\nAffected versions of the package are vulnerable to Information Disclosure because the `InputStream` is not closed on exception.\r\n\r\n## Remediation\r\nUpgrade `commons-fileupload` to version 1.3.2 or higher.\r\n\r\n## References\r\n- [Github ChangeLog](https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml#L56)\r\n- [Github Commit](https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814)",
+        "disclosureTime": "2014-02-17T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.3.2"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "FileUpload",
+              "filePath": "org/apache/commons/fileupload/FileUpload.java",
+              "functionName": "parseRequest"
+            },
+            "version": [
+              "[,1.0-rc1)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "FileUploadBase",
+              "filePath": "org/apache/commons/fileupload/FileUploadBase.java",
+              "functionName": "parseRequest"
+            },
+            "version": [
+              "[1.0-rc1,1.2.0)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "FileUploadBase$FileItemIteratorImpl",
+              "filePath": "org/apache/commons/fileupload/FileUploadBase$FileItemIteratorImpl.java",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[1.2.0 ,1.3.2)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.apache.commons.fileupload.FileUpload",
+              "functionName": "parseRequest"
+            },
+            "version": [
+              "[,1.0-rc1)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.apache.commons.fileupload.FileUploadBase",
+              "functionName": "parseRequest"
+            },
+            "version": [
+              "[1.0-rc1,1.2.0)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.apache.commons.fileupload.FileUploadBase$FileItemIteratorImpl",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[1.2.0 ,1.3.2)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-COMMONSFILEUPLOAD-31540",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-200"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "commons-fileupload",
+          "groupId": "commons-fileupload"
+        },
+        "modificationTime": "2020-06-22T17:20:16.073581Z",
+        "moduleName": "commons-fileupload:commons-fileupload",
+        "packageManager": "maven",
+        "packageName": "commons-fileupload:commons-fileupload",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-02-17T08:05:48Z",
+        "references": [
+          {
+            "title": "Github ChangeLog",
+            "url": "https://github.com/apache/commons-fileupload/blob/master/src/changes/changes.xml%23L56"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/commons-fileupload/commit/5b4881d7f75f439326f54fa554a9ca7de6d60814"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,1.3.2)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Information Exposure",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "commons-fileupload:commons-fileupload@1.3.1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "commons-fileupload:commons-fileupload",
+        "version": "1.3.1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2019-04-10T16:07:04.634619Z",
+        "credit": [
+          "Mario Areias"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[dom4j:dom4j](https://github.com/dom4j/dom4j) is a flexible XML framework for Java. *Note*: this artifact has been deprecated for `org.dom4j:dom4j`.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection due to not validating the `QName` inputs.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `dom4j:dom4j`.\n## References\n- [GitHub Commit](https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387)\n- [GitHub Issue](https://github.com/dom4j/dom4j/issues/48)\n- [Ihacktoprotect Blog](https://ihacktoprotect.com/post/dom4j-xml-injection/)\n",
+        "disclosureTime": "2018-07-01T19:12:29Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [
+          {
+            "functionId": {
+              "className": "Namespace",
+              "filePath": "org/dom4j/Namespace.java",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "QName",
+              "filePath": "org/dom4j/QName.java",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.dom4j.Namespace",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.dom4j.QName",
+              "functionName": "<init>"
+            },
+            "version": [
+              "[0,]"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-DOM4J-174153",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-1000632"
+          ],
+          "CWE": [
+            "CWE-611"
+          ],
+          "GHSA": [
+            "GHSA-6pcc-3rfx-4gpm"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "dom4j",
+          "groupId": "dom4j"
+        },
+        "modificationTime": "2020-09-21T06:25:14.227405Z",
+        "moduleName": "dom4j:dom4j",
+        "packageManager": "maven",
+        "packageName": "dom4j:dom4j",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-08-21T14:16:13Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/dom4j/dom4j/commit/e598eb43d418744c4dbf62f647dd2381c9ce9387"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/dom4j/dom4j/issues/48"
+          },
+          {
+            "title": "Ihacktoprotect Blog",
+            "url": "https://ihacktoprotect.com/post/dom4j-xml-injection/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-core@4.3.7.Final",
+          "dom4j:dom4j@1.6.1"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "dom4j:dom4j",
+        "version": "1.6.1"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:19.341000Z",
+        "credit": [
+          "David Jorm"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[javax.servlet:jstl](https://mvnrepository.com/artifact/javax.servlet/jstl) is a collection of useful JSP tags which encapsulates the core functionality common to many JSP applications.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. Apache Standard Taglibs before 1.2.3 allows remote attackers to execute arbitrary code or conduct external XML entity (XXE) attacks via a crafted XSLT extension in a `<x:parse>` or `<x:transform>` JSTL XML tag.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nThere is no fixed version for `javax.servlet:jstl`.\n## References\n- [Apache Mail Archive](http://mail-archives.us.apache.org/mod_mbox/www-announce/201502.mbox/%3C82207A16-6348-4DEE-877E-F7B87292576A@apache.org%3E)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254)\n- [RedHat CVE Database](https://access.redhat.com/security/cve/CVE-2015-0254)\n",
+        "disclosureTime": "2015-02-27T16:13:27Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-JAVAXSERVLET-30449",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-0254"
+          ],
+          "CWE": [
+            "CWE-94"
+          ],
+          "GHSA": [
+            "GHSA-6x4w-8w53-xrvv"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "jstl",
+          "groupId": "javax.servlet"
+        },
+        "modificationTime": "2019-04-18T07:20:47.242780Z",
+        "moduleName": "javax.servlet:jstl",
+        "packageManager": "maven",
+        "packageName": "javax.servlet:jstl",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2015-02-27T16:51:55Z",
+        "references": [
+          {
+            "title": "Apache Mail Archive",
+            "url": "http://mail-archives.us.apache.org/mod_mbox/www-announce/201502.mbox/%3C82207A16-6348-4DEE-877E-F7B87292576A@apache.org%3E"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-0254"
+          },
+          {
+            "title": "RedHat CVE Database",
+            "url": "https://access.redhat.com/security/cve/CVE-2015-0254"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[0,]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "javax.servlet:jstl@1.2"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "javax.servlet:jstl",
+        "version": "1.2"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:19.659000Z",
+        "credit": [
+          "Tao Wang"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[`ognl:ognl`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22ognl%22) is a simple Expression Language (EL) for Java.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks.\nApache Struts 2.0.0 through 2.3.24.1 does not properly cache method references when used with OGNL before 3.0.12, which allows remote attackers to cause a denial of service (block access to a web site) via unspecified vectors.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `ognl:ognl` to version 3.0.12 or higher.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093)\n- [GitHub Commit](https://github.com/jkuhnert/ognl/commit/ae43073fbf38db8371ff4f8bf2a966ee3b5f7e92)\n",
+        "disclosureTime": "2016-06-02T02:16:48.918000Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.0.12"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-OGNL-30474",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-3093"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "ognl",
+          "groupId": "ognl"
+        },
+        "modificationTime": "2019-06-02T07:37:12.793609Z",
+        "moduleName": "ognl:ognl",
+        "packageManager": "maven",
+        "packageName": "ognl:ognl",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-02T02:16:48.918000Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/jkuhnert/ognl/commit/ae43073fbf38db8371ff4f8bf2a966ee3b5f7e92"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,3.0.12)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "ognl:ognl@3.0.6"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "ognl:ognl",
+        "version": "3.0.6"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:P",
+        "alternativeIds": [],
+        "creationTime": "2020-12-08T19:30:16.810323Z",
+        "credit": [
+          "Alvaro Munoz",
+          "Masato Anzai"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE). The vulnerability exists due to improper input validation when processing certain tag's attributes. The application performs double evaluation of the code if a developer applied forced OGNL evaluation by using the `%{...}` syntax. A remote attacker can send a specially crafted request to the application and execute arbitrary code on the target system.\r\n\r\nSuccessful exploitation of this vulnerability may result in complete compromise of vulnerable system.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.26 or higher.\n## References\n- [Apache Security Advisory](https://cwiki.apache.org/confluence/display/WW/S2-061)\n- [GitHub Commit](https://github.com/apache/struts/commit/45667346629455f7ea125bff36bf9b763b7e8463)\n- [PoC](https://github.com/phil-fly/CVE-2020-17530)\n",
+        "disclosureTime": "2020-12-08T19:25:45Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.5.26"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-1049003",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-17530"
+          ],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-12-08T19:30:16.810348Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-12-08T19:25:43Z",
+        "references": [
+          {
+            "title": "Apache Security Advisory",
+            "url": "https://cwiki.apache.org/confluence/display/WW/S2-061"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/45667346629455f7ea125bff36bf9b763b7e8463"
+          },
+          {
+            "title": "PoC",
+            "url": "https://github.com/phil-fly/CVE-2020-17530"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0, 2.5.26)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Remote Code Execution (RCE)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:56Z",
+        "credit": [
+          "Viettel Information Security Center"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n`ValueStack` defines special `top` object which represents root of execution context. It can be used to manipulate Struts' internals or can be used to affect container's settings.\n\n## References\n- [Vulnerability Summary](http://struts.apache.org/docs/s2-026.html)\n",
+        "disclosureTime": "2015-07-01T16:51:56Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.24.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30060",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-5209"
+          ],
+          "CWE": [
+            "CWE-284"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2019-10-27T12:32:35.077634Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2015-07-01T16:51:56Z",
+        "references": [
+          {
+            "title": "Vulnerability Summary",
+            "url": "http://struts.apache.org/docs/s2-026.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0, 2.3.24.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Manipulation of Struts' internals",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:F/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2017-03-19T10:28:21.873000Z",
+        "credit": [
+          "Nike Zheng"
+        ],
+        "cvssScore": 10,
+        "description": "## Overview\r\n[`org.apache.struts:struts2-core`](https://cwiki.apache.org/confluence/display/WW/Home) is an elegant, extensible framework for building enterprise-ready Java web applications.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary Command Execution while uploading files with the Jakarta Multipart parser. This particular vulnerability can be exploited by an attacker by sending a crafted request to upload a file to the vulnerable server that uses a Jakarta-based plugin to process the upload request.\r\n\r\nThe attacker can then send malicious code in the `Content-Type`, `Content-Disposition` or `Content-Length` HTTP headers, which will then be executed by the vulnerable server. [A proof of concept](https://github.com/tengzhangchao/Struts2_045-Poc) that demonstrates the attack scenario is publicly available and the vulnerability is being [actively exploited in the wild](https://www.theregister.co.uk/2017/03/09/apache_under_attack_patch_for_zero_day_available/).\r\n\r\nAlthough maintainers of the open source project immediately patched the vulnerability, Struts servers that have yet to install the update remain under attack by hackers who exploit it to inject commands of their choice.\r\n\r\nThis attack can be achieved without authentication. To make matters worse, web applications don't necessarily need to successfully upload a malicious file to exploit this vulnerability, as just the presence of the vulnerable Struts library within an application is enough to exploit the vulnerability.\r\n\r\n## Remediation\r\nUpgrade `org.apache.struts:struts2-core` to version 2.3.32, 2.5.10.1 or higher.\n\n## References\n- [CVE Details](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638)\n- [Exploit DB](https://exploit-db.com/exploits/41614)\n- [Exploit DB](https://www.exploit-db.com/exploits/41570/)\n- [GitHub Commit](https://github.com/rapid7/metasploit-framework/pull/8072/commits/fc0f63e77471baa40057effaaa8be0f205adc6b7)\n- [GitHub Issue](https://github.com/rapid7/metasploit-framework/issues/8064)\n- [GitHub PR](https://github.com/rapid7/metasploit-framework/pull/8072)\n- [PoC](https://github.com/tengzhangchao/Struts2_045-Poc)\n- [Struts Wiki](https://cwiki.apache.org/confluence/display/WW/S2-045)\n- [Talos Intelligence Blog](http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html)\n",
+        "disclosureTime": "2017-03-05T22:00:00Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "2.3.32",
+          "2.5.10.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "JakartaMultiPartRequest",
+              "filePath": "org/apache/struts2/dispatcher/multipart/JakartaMultiPartRequest.java",
+              "functionName": "buildErrorMessage"
+            },
+            "version": [
+              "[2.3.5, 2.3.32)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "FileUploadInterceptor",
+              "filePath": "org/apache/struts2/interceptor/FileUploadInterceptor.java",
+              "functionName": "intercept"
+            },
+            "version": [
+              "[2.5.0, 2.5.10.1)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.apache.struts2.dispatcher.multipart.JakartaMultiPartRequest",
+              "functionName": "buildErrorMessage"
+            },
+            "version": [
+              "[2.3.5, 2.3.32)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.apache.struts2.interceptor.FileUploadInterceptor",
+              "functionName": "intercept"
+            },
+            "version": [
+              "[2.5.0, 2.5.10.1)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30207",
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-5638"
+          ],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-02-12T14:38:11.454392Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-03-21T15:30:44Z",
+        "references": [
+          {
+            "title": "CVE Details",
+            "url": "https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-5638"
+          },
+          {
+            "title": "Exploit DB",
+            "url": "https://exploit-db.com/exploits/41614"
+          },
+          {
+            "title": "Exploit DB",
+            "url": "https://www.exploit-db.com/exploits/41570/"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/rapid7/metasploit-framework/pull/8072/commits/fc0f63e77471baa40057effaaa8be0f205adc6b7"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/rapid7/metasploit-framework/issues/8064"
+          },
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/rapid7/metasploit-framework/pull/8072"
+          },
+          {
+            "title": "PoC",
+            "url": "https://github.com/tengzhangchao/Struts2_045-Poc"
+          },
+          {
+            "title": "Struts Wiki",
+            "url": "https://cwiki.apache.org/confluence/display/WW/S2-045"
+          },
+          {
+            "title": "Talos Intelligence Blog",
+            "url": "http://blog.talosintelligence.com/2017/03/apache-0-day-exploited.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.7, 2.3.32)",
+            "[2.5.0, 2.5.10.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Arbitrary Code Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.315000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Command Injection. When Dynamic Method Invocation was enabled, a remote attackers could execute arbitrary code via the prefix method, related to chained expressions.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/39756)\n- [GitHub Commit](https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081)\n",
+        "disclosureTime": "2016-04-22T04:32:51Z",
+        "exploit": "High",
+        "fixedIn": [
+          "2.3.20.2",
+          "2.3.24.2",
+          "2.3.28.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30770",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-3081"
+          ],
+          "CWE": [
+            "CWE-77"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-06-12T14:37:05.172858Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-04-22T04:32:51Z",
+        "references": [
+          {
+            "title": "Exploit DB",
+            "url": "https://exploit-db.com/exploits/39756"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0, 2.3.20.2)",
+            "[2.3.24, 2.3.24.2)",
+            "[2.3.28, 2.3.28.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Command Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.327000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22) is a free open-source solution for creating Java web applications.\n\nAffected versions of this package are vulnerable to Arbitrary Code Execution. It allows remote attackers to execute arbitrary code via the stylesheet location parameter.\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3082)",
+        "disclosureTime": "2016-04-22T02:36:52.273000Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.20.2",
+          "2.3.24.2",
+          "2.3.28.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30771",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-3082"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2019-12-03T17:25:46.061028Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-04-22T02:36:52.273000Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/6bd694b7980494c12d49ca1bf39f12aec3e03e2f"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3082"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2,2.3.20.2)",
+            "[2.3.24,2.3.24.2)",
+            "[2.3.28,2.3.28.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Arbitrary Code Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.339000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\r\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\r\nApache Struts 2.3.20.x before 2.3.20.3, 2.3.24.x before 2.3.24.3, and 2.3.28.x before 2.3.28.1, when Dynamic Method Invocation is enabled, allow remote attackers to execute arbitrary code via vectors related to an ! (exclamation mark) operator to the REST Plugin.\r\n\r\n## References\r\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3087)",
+        "disclosureTime": "2016-06-02T00:40:36Z",
+        "exploit": "High",
+        "fixedIn": [
+          "2.3.20.2",
+          "2.3.24.3",
+          "2.3.28.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30772",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-3087"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2019-07-19T13:10:41.364553Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-02T00:40:36Z",
+        "references": [
+          {
+            "title": "Exploit DB",
+            "url": "https://exploit-db.com/exploits/39919"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/6bd694b7980494c12d49ca1bf39f12aec3e03e2f"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/98d2692e434fe7f4d445ade24fe2c9860de1c13f"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3087"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2,2.3.20.2)",
+            "[2.3.24,2.3.24.3)",
+            "[2.3.28,2.3.28.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Arbitrary Command Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.353000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 6.1,
+        "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\nCross-site Scripting (XSS) vulnerability in the URLDecoder function in JRE before 1.8, as used in Apache Struts 2.x before 2.3.28, when using a single byte page encoding, allows remote attackers to inject arbitrary web script or HTML via multi-byte characters in a url-encoded parameter.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4003)",
+        "disclosureTime": "2016-03-16T06:52:13.014000Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.28"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30773",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4003"
+          ],
+          "CWE": [
+            "CWE-79"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2019-06-02T07:38:04.646057Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-03-16T06:52:13.014000Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/5421930b49822606792f36653b17d3d95ef106f9"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/72471d7075681bea52046645ad7aa34e9c53751e"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/a89bbe22cd2461748d595a89a254de888a415e6c"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4003"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,2.3.28)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Cross-site Scripting (XSS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.364000Z",
+        "credit": [
+          "Takeshi Terada"
+        ],
+        "cvssScore": 8.8,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Cross-site Request Forgery (CSRF). It mishandles token validation, which allows remote attackers to conduct CSRF attacks via unspecified vectors.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [Apache Struts Security Bulletin](https://struts.apache.org/docs/s2-038.html)\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4430)\n",
+        "disclosureTime": "2016-06-20T07:00:37Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.29"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30774",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4430"
+          ],
+          "CWE": [
+            "CWE-352"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-06-12T14:36:54.902858Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-20T07:00:37Z",
+        "references": [
+          {
+            "title": "Apache Struts Security Bulletin",
+            "url": "https://struts.apache.org/docs/s2-038.html"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4430"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20,2.3.29)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Cross-site Request Forgery (CSRF)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.377000Z",
+        "credit": [
+          "Takeshi Terada"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks by leveraging a default method.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [Apache Struts Security Bulletin](https://struts.apache.org/docs/s2-040.html)\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4431)\n",
+        "disclosureTime": "2016-06-21T04:49:27Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.29"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30775",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4431"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-06-12T14:37:01.532444Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-21T04:49:27Z",
+        "references": [
+          {
+            "title": "Apache Struts Security Bulletin",
+            "url": "https://struts.apache.org/docs/s2-040.html"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4431"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20,2.3.29)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Access Restriction Bypass",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.390000Z",
+        "credit": [
+          "Takeshi Terada"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks via a crafted request.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433)\n",
+        "disclosureTime": "2016-06-21T01:33:07Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.29"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30776",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4433"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-06-12T14:36:50.879545Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-21T01:33:07Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20, 2.3.29)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Access Restriction Bypass",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.415000Z",
+        "credit": [
+          "Takeshi Terada"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[`org.apache.struts:struts2-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22struts2-core%22)\nAffected versions of the package are vulnerable to Directory Traversal.\n\n## Details\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\r\n\r\nDirectory Traversal vulnerabilities can be generally divided into two types:\r\n\r\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\r\n\r\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\r\n\r\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\r\n\r\n```\r\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\r\n```\r\n**Note** `%2e` is the URL encoded version of `.` (dot).\r\n\r\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \r\n\r\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n2018-04-15 22:04:29 .....           19           19  good.txt\r\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\r\n```\n\n\n## References\n- [Apache Security Advisory](http://struts.apache.org/docs/s2-042.html)\n",
+        "disclosureTime": "2016-10-19T01:09:09.263000Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.31"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-30778",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-6795"
+          ],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2019-06-02T07:38:06.057284Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-10-19T01:09:09.263000Z",
+        "references": [
+          {
+            "title": "Apache Security Advisory",
+            "url": "http://struts.apache.org/docs/s2-042.html"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/030ffa33543f8953306ed0c0dc815c7fb74d7129"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/8e67b9144aa643769b261e2492cb561e04d016ab"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20,2.3.31)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Directory Traversal",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:O/RC:R",
+        "alternativeIds": [],
+        "creationTime": "2017-09-06T17:28:23.339000Z",
+        "credit": [
+          "LGTM Security Team"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\r\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\r\n\r\nThe REST Plugin in affected versions use a `XStreamHandler` with an instance of XStream for deserialization without any type filtering. By design, there are few limits to the type of objects XStream can handle. This flexibility comes at a price. The XML generated or consumed by XStream includes all information required to build Java objects of almost any type. The provided XML data is used by XStream to unmarshal Java objects. An attacker could use this flaw to execute arbitrary code or conduct further attacks.\r\n\r\n[A working exploit](https://github.com/rapid7/metasploit-framework/commit/5ea83fee5ee8c23ad95608b7e2022db5b48340ef) is publicly available and [is actively](https://www.imperva.com/blog/2017/09/cve-2017-9805-analysis-of-apache-struts-rce-vulnerability-in-rest-plugin/) exploited in the wild.\r\n\r\nYou can read more about this vulnerability [on our blog](https://snyk.io/blog/equifax-breach-vulnerable-open-source-libraries/).\r\n\r\n# Details\r\nSerialization is a process of converting an object into a sequence of bytes which can be persisted to a disk or database or can be sent through streams. The reverse process of creating object from sequence of bytes is called deserialization. Serialization is commonly used for communication (sharing objects between multiple hosts) and persistence (store the object state in a file or a database). It is an integral part of popular protocols like _Remote Method Invocation (RMI)_, _Java Management Extension (JMX)_, _Java Messaging System (JMS)_, _Action Message Format (AMF)_, _Java Server Faces (JSF) ViewState_, etc.\r\n\r\n_Deserialization of untrusted data_ ([CWE-502](https://cwe.mitre.org/data/definitions/502.html)), is when the application deserializes untrusted data without sufficiently verifying that the resulting data will be valid, letting the attacker control the state or the flow of the execution. \r\n\r\nJava deserialization issues have been known for years. However, interest in the issue intensified greatly in 2015, when classes that could be abused to achieve remote code execution were found in a [popular library (Apache Commons Collection)](https://snyk.io/vuln/SNYK-JAVA-COMMONSCOLLECTIONS-30078). These classes were used in zero-days affecting IBM WebSphere, Oracle WebLogic and many other products.\r\n\r\nAn attacker just needs to identify a piece of software that has both a vulnerable class on its path, and performs deserialization on untrusted data. Then all they need to do is send the payload into the deserializer, getting the command executed.\r\n\r\n> Developers put too much trust in Java Object Serialization. Some even de-serialize objects pre-authentication. When deserializing an Object in Java you typically cast it to an expected type, and therefore Java's strict type system will ensure you only get valid object trees. Unfortunately, by the time the type checking happens, platform code has already created and executed significant logic. So, before the final type is checked a lot of code is executed from the readObject() methods of various objects, all of which is out of the developer's control. By combining the readObject() methods of various classes which are available on the classpath of the vulnerable application an attacker can execute functions (including calling Runtime.exec() to execute local OS commands).\r\n- Apache Blog\r\n\r\n\r\n## Remediation\r\nDevelopers are strongly advised to upgrade their _Apache Struts_ components to version `2.3.34`, `2.5.13` or higher.\r\n\r\nIt is possible that some REST actions stop working because of applied default restrictions on available classes. In this case please investigate the new interfaces that were introduced to allow class restrictions per action, those interfaces are:\r\n* org.apache.struts2.rest.handler.AllowedClasses\r\n* org.apache.struts2.rest.handler.AllowedClassNames\r\n* org.apache.struts2.rest.handler.XStreamPermissionProvider\r\n\r\nIf for some reason upgrading is not an option, consider the following workarounds:\r\n1. Disable handling XML pages and requests to such pages\r\n```xml\r\n<constant name=\"struts.action.extension\" value=\"xhtml,,json\" />\r\n```\r\n\r\n2. Override getContentType in XStreamHandler\r\n```java\r\n public class MyXStreamHandler extends XStreamHandler { \r\n   public String getContentType() {\r\n     return \"not-existing-content-type-@;/&%$#@\";\r\n   }\r\n }\r\n```\r\n\r\n3. Register the handler by overriding the one provided by the framework in your struts.xml\r\n```xml\r\n<bean type=\"org.apache.struts2.rest.handler.ContentTypeHandler\" name=\"myXStreamHandmer\" class=\"com.company.MyXStreamHandler\"/>\r\n<constant name=\"struts.rest.handlerOverride.xml\" value=\"myXStreamHandler\"/>\r\n```\r\n\r\n## References\r\n- [LGTM Advisory](https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement)\r\n- [LGTM Vulnerability Details](https://lgtm.com/blog/apache_struts_CVE-2017-9805)\r\n- [Apache Struts Statement on Equifax Security Breach](https://blogs.apache.org/foundation/entry/apache-struts-statement-on-equifax)\r\n- [Apache Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-052)",
+        "disclosureTime": "2017-09-05T17:28:23Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "2.3.34",
+          "2.5.13"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-31495",
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-9805"
+          ],
+          "CWE": [
+            "CWE-20",
+            "CWE-502"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2019-07-17T13:50:20.206465Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-09-06T17:28:23Z",
+        "references": [
+          {
+            "title": "Apache Security Bulletin",
+            "url": "https://cwiki.apache.org/confluence/display/WW/S2-052"
+          },
+          {
+            "title": "Apache Struts Statement on Equifax Security Breach",
+            "url": "https://blogs.apache.org/foundation/entry/apache-struts-statement-on-equifax"
+          },
+          {
+            "title": "Exploit DB",
+            "url": "https://www.exploit-db.com/exploits/42627"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/19494718865f2fb7da5ea363de3822f87fbda26"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/6dd6e5cfb7b5e020abffe7e8091bd63fe97c10a"
+          },
+          {
+            "title": "LGTM Advisory",
+            "url": "https://lgtm.com/blog/apache_struts_CVE-2017-9805_announcement"
+          },
+          {
+            "title": "LGTM Vulnerability Details",
+            "url": "https://lgtm.com/blog/apache_struts_CVE-2017-9805"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,2.3.34)",
+            "[2.4,2.5.13)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Arbitrary Command Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-09-12T12:47:32.905000Z",
+        "credit": [
+          "Yasser Zamani"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) attacks.\nWhen using a Spring AOP functionality to secure Struts actions it is possible to perform a DoS attack.\n\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.33, 2.5.12 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-049.html)\n- [Struts Announcements Mailing List](https://lists.apache.org/thread.html/3795c4dd46d9ec75f4a6eb9eca11c11edd3e796c6c1fd7b17b5dc50d@%3Cannouncements.struts.apache.org%3E)\n",
+        "disclosureTime": "2017-07-13T15:29:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.33",
+          "2.5.12"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-31500",
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-9787"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-04-06T16:44:43.427689Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-09-12T12:47:32.905000Z",
+        "references": [
+          {
+            "title": "Apache Security Advisory",
+            "url": "https://lists.apache.org/thread.html/3795c4dd46d9ec75f4a6eb9eca11c11edd3e796c6c1fd7b17b5dc50d@%3Cannouncements.struts.apache.org%3E"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/086b63735527d4bb0c1dd0d86a7c0374b825ff2"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/0d6442bab5b44d93c4c2e63c5335f0a331333b9"
+          },
+          {
+            "title": "Struts Security Bulletin",
+            "url": "http://struts.apache.org/docs/s2-049.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.7,2.3.33)",
+            "[2.5,2.5.12)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-09-12T12:47:32.905000Z",
+        "credit": [
+          "Adam Cazzolla",
+          "Jonathan Bullock"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS) attacks. This is due to an incomplete fix for [CVE-2017-7672](https://snyk.io/vuln/SNYK-JAVA-ORGAPACHESTRUTS-31499). If an application allows enter an URL in a form field and built-in URLValidator is used, it is possible to prepare a special URL which will be used to overload server process when performing validation of the URL.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.34, 2.5.13 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-050.html)\n",
+        "disclosureTime": "2017-08-23T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.34",
+          "2.5.13"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-31501",
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-9804"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-04-06T16:44:43.213193Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-09-12T12:47:32.905000Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/3fddfb6eb562d597c935084e9e81d43ed6bcd02"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/418a20c0594f23764fe29ced400c1219239899a"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/744c1f409d983641af3e8e3b573c2f2d2c2c6d9"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/8a04e80f01350c90f053d71366d5e0c2186fded"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/9d47af6ffa355977b5acc713e6d1f25fac260a2"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/a05259ed69a5a48379aa91650e4cd1cb4bd6e5a"
+          },
+          {
+            "title": "Struts Security Bulletin",
+            "url": "http://struts.apache.org/docs/s2-050.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.7,2.3.34)",
+            "[2.5,2.5.13)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-09-12T12:47:32.905000Z",
+        "credit": [
+          "Huijun Chen",
+          "Xiaolong Zhu"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (ReDoS) attacks. The REST Plugin is using outdated XStream library which is vulnerable and allow perform a DoS attack using malicious request with specially crafted XML payload.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\r\n\r\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\r\n\r\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\r\n\r\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\r\n\r\nTwo common types of DoS vulnerabilities:\r\n\r\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\r\n\r\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](npm:ws:20171108)\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.34, 2.5.13 or higher.\n\n## References\n- [Struts Security Bulletin](http://struts.apache.org/docs/s2-051.html)\n",
+        "disclosureTime": "2017-08-23T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.34",
+          "2.5.13"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-31502",
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-9793"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-04-06T16:44:43.003236Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-09-12T12:47:32.905000Z",
+        "references": [
+          {
+            "title": "Struts Security Bulletin",
+            "url": "http://struts.apache.org/docs/s2-051.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.7,2.3.34)",
+            "[2.5,2.5.13)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F",
+        "alternativeIds": [],
+        "creationTime": "2017-09-06T17:28:23.339000Z",
+        "credit": [
+          "Lupin",
+          "David Greene",
+          "Roland McIntosh"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\r\n[Apache Struts2](http://struts.apache.org/) is a popular open-source framework for developing web applications in the Java programming language.\r\n\r\nAffected versions of this package are vulnerable to Arbitrary Code Execution. An unauthenticated attack may be able to exploit this \r\nWhen using expression literals or forcing expression in Freemarker tags (see example below) and using request values can lead to RCE attack.\r\n\r\n```xml\r\n<@s.hidden name=\"redirectUri\" value=redirectUri />\r\n<@s.hidden name=\"redirectUri\" value=\"${redirectUri}\" />\r\n<@s.hidden name=\"${redirectUri}\"/>\r\n```\r\n\r\nIn both cases a writable property is used in the value attribute and in both cases this is threatened as an expression by Freemarker. Please be aware that using Struts expression evaluation style is safe:\r\n\r\n```\r\n<@s.hidden name=\"redirectUri\" value=\"%{redirectUri}\" />\r\n<@s.hidden name=\"%{redirectUri}\"/>\r\n```\r\n\r\n## Remediation\r\nDevelopers are strongly advised to upgrade their _Apache Struts_ components to version `2.3.34`, `2.5.12` or higher.\r\n\r\n## References\r\n- [Apache Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-053)",
+        "disclosureTime": "2017-09-05T17:28:23Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "2.3.34",
+          "2.5.12"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-31503",
+        "identifiers": {
+          "CVE": [
+            "CVE-2017-12611"
+          ],
+          "CWE": [
+            "CWE-20",
+            "CWE-502"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-04-06T16:44:42.794611Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2017-09-06T17:28:23Z",
+        "references": [
+          {
+            "title": "Apache Security Bulletin",
+            "url": "https://cwiki.apache.org/confluence/display/WW/S2-053"
+          },
+          {
+            "title": "Exploit",
+            "url": "https://github.com/brianwrf/S2-053-CVE-2017-12611"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/2306f5f7fad7f0157f216f34331238feb0539fa"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/637ad1c3707266c33daabb18d7754e795e6681f"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,2.3.34)",
+            "[2.4,2.5.12)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Arbitrary Code Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2018-08-22T00:00:00Z",
+        "credit": [
+          "Man Yue Mo"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution. When the namespace value is not set for a result defined in underlying xml configurations, and in same time, its upper action(s) configurations have no or wildcard namespace, an attacker may be able to conduct a remote code execution attack. They could also use the opportunity when using a url tag which does not have a value and action set and in same time, its upper action(s) configurations have no or wildcard namespace.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.35, 2.5.17 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/45367)\n- [Exploit DB](https://www.exploit-db.com/exploits/45367)\n- [GitHub Commit](https://github.com/apache/struts/commit/b3bad5ea44f3fd9edb2cb491192c5900f46d45d3)\n- [Lgtm Blog](https://lgtm.com/blog/apache_struts_CVE-2018-11776)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1620019)\n- [Struts2 Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-057)\n",
+        "disclosureTime": "2018-08-17T00:00:00Z",
+        "exploit": "High",
+        "fixedIn": [
+          "2.3.35",
+          "2.5.17"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "ActionChainResult",
+              "filePath": "com/opensymphony/xwork2/ActionChainResult.java",
+              "functionName": "execute"
+            },
+            "version": [
+              "[2.3.0, 2.3.35)",
+              "[2.5.0, 2.5.17)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "com.opensymphony.xwork2.ActionChainResult",
+              "functionName": "execute"
+            },
+            "version": [
+              "[2.3.0, 2.3.35)",
+              "[2.5.0, 2.5.17)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-32477",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-11776"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-06-12T14:37:03.442655Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2018-08-22T11:53:44Z",
+        "references": [
+          {
+            "title": "Exploit DB",
+            "url": "https://exploit-db.com/exploits/45367"
+          },
+          {
+            "title": "Exploit DB",
+            "url": "https://www.exploit-db.com/exploits/45367"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/b3bad5ea44f3fd9edb2cb491192c5900f46d45d3"
+          },
+          {
+            "title": "Lgtm Blog",
+            "url": "https://lgtm.com/blog/apache_struts_CVE-2018-11776"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1620019"
+          },
+          {
+            "title": "Struts2 Security Bulletin",
+            "url": "https://cwiki.apache.org/confluence/display/WW/S2-057"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.0, 2.3.35)",
+            "[2.5.0, 2.5.17)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Remote Code Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2019-07-16T11:14:42.540198Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Improper Action Name Cleanup. It allowed attackers to have unspecified impact via vectors related to improper action name clean up.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29, 2.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/237432512df0e27013f7c7b9ab59fdce44ca34a5)\n- [GitHub Commit](https://github.com/apache/struts/commit/27ca165ddbf81c84bafbd083b99a18d89cc49ca7)\n",
+        "disclosureTime": "2016-09-19T05:25:51Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.29",
+          "2.5.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-451610",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4436"
+          ],
+          "CWE": [
+            "CWE-459"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-06-12T14:37:05.087311Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-09-19T05:25:51Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/237432512df0e27013f7c7b9ab59fdce44ca34a5"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/27ca165ddbf81c84bafbd083b99a18d89cc49ca7"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0, 2.3.29)",
+            "[2.5, 2.5.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Improper Action Name Cleanup",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-08-23T13:23:19.812650Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The URLValidator class allows remote attackers to cause a denial of service via a null value for a URL field.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.3.29, 2.5.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152)\n- [GitHub Commit](https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465)\n",
+        "disclosureTime": "2016-06-20T07:45:43Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.29",
+          "2.5.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-460223",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4465"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-06-12T14:36:58.259938Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-20T07:45:43Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20, 2.3.29)",
+            "[2.5,2.5.1)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H/E:F/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-21T14:31:35.397242Z",
+        "credit": [
+          "Matthias Kaiser"
+        ],
+        "cvssScore": 9.8,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Remote Code Execution (RCE). Forced double OGNL evaluation, when evaluated on raw user input in tag attributes, may lead to remote code execution.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.22 or higher.\n## References\n- [Exploit](https://www.exploit-db.com/exploits/49068)\n- [Proof Of Concept](https://github.com/PrinceFPF/CVE-2019-0230)\n- [Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-059)\n",
+        "disclosureTime": "2020-08-11T14:14:01Z",
+        "exploit": "Functional",
+        "fixedIn": [
+          "2.5.22"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-608097",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-0230"
+          ],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-08-21T15:24:46.434374Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-21T14:06:54Z",
+        "references": [
+          {
+            "title": "Exploit",
+            "url": "https://www.exploit-db.com/exploits/49068"
+          },
+          {
+            "title": "Proof Of Concept",
+            "url": "https://github.com/PrinceFPF/CVE-2019-0230"
+          },
+          {
+            "title": "Security Bulletin",
+            "url": "https://cwiki.apache.org/confluence/display/WW/S2-059"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0, 2.5.22)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "critical",
+        "title": "Remote Code Execution (RCE)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-08-21T14:39:32.053413Z",
+        "credit": [
+          "Takeshi Terada of Mitsui Bussan Secure Directions",
+          "Inc"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). When a file upload is performed to an `Action` that exposes the file with a getter, an attacker may manipulate the request such that the working copy of the uploaded file is set to read-only. As a result, subsequent actions on the file will fail with an error. It might also be possible to set the Servlet container's temp directory to read-only, such that subsequent upload actions will fail.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5.22 or higher.\n## References\n- [Security Bulletin](https://cwiki.apache.org/confluence/display/WW/S2-060)\n",
+        "disclosureTime": "2020-08-11T14:36:56Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "2.5.22"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-608098",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-0233"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-08-21T15:23:58.788822Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-08-21T14:36:29Z",
+        "references": [
+          {
+            "title": "Security Bulletin",
+            "url": "https://cwiki.apache.org/confluence/display/WW/S2-060"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0, 2.5.22)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-09-04T15:56:51.451242Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 8.8,
+        "description": "## Overview\n[org.apache.struts:struts2-core](https://github.com/apache/struts) is a popular open-source framework for developing web applications in the Java programming language.\n\nAffected versions of this package are vulnerable to Unrestricted Upload of File with Dangerous Type. A local code execution issue exists in Apache Struts2 when processing malformed XSLT files, which could let a malicious user upload and execute arbitrary files.\n## Remediation\nUpgrade `org.apache.struts:struts2-core` to version 2.5 or higher.\n## References\n- [Bug Report](https://issues.apache.org/jira/browse/WW-5055)\n- [GitHub Commit](https://github.com/apache/struts/commit/4271682d2b944e9022e4e4c499df43e0ce7e58fd)\n",
+        "disclosureTime": "2019-12-05T15:43:54Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTS-609765",
+        "identifiers": {
+          "CVE": [
+            "CVE-2012-1592"
+          ],
+          "CWE": [
+            "CWE-434"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "struts2-core",
+          "groupId": "org.apache.struts"
+        },
+        "modificationTime": "2020-09-10T21:57:04.385281Z",
+        "moduleName": "org.apache.struts:struts2-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts:struts2-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-09-04T15:56:53Z",
+        "references": [
+          {
+            "title": "Bug Report",
+            "url": "https://issues.apache.org/jira/browse/WW-5055"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/4271682d2b944e9022e4e4c499df43e0ce7e58fd"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,2.5)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Unrestricted Upload of File with Dangerous Type",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts:struts2-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.673000Z",
+        "credit": [
+          "rskvp93"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nAffected versions of the package are vulnerable to Parameter Alteration. ValueStack defines special top object which represents root of execution context. It can be used to manipulate Struts' internals or can be used to affect container's settings\n\n\n## References\n- [Apache Security Advisory](https://struts.apache.org/docs/s2-026.html)\n",
+        "disclosureTime": "2015-09-28T16:59:30Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.24.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30798",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-5209"
+          ],
+          "CWE": [
+            "CWE-235"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2019-06-02T10:19:49.301976Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2015-09-28T16:59:30Z",
+        "references": [
+          {
+            "title": "Apache Security Advisory",
+            "url": "https://struts.apache.org/docs/s2-026.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2,2.3.24.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Parameter Alteration",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.686000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 8.8,
+        "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Improper Input Validation via a `%{}` sequence in a tag attribute, aka forced double OGNL evaluation.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.28 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/15857a69e7baf3675804495a5954cd0756ac8364)\n",
+        "disclosureTime": "2016-03-16T05:58:06Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.28"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30799",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-0785"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2020-06-12T14:36:54.876158Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-03-16T05:58:06Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/15857a69e7baf3675804495a5954cd0756ac8364"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2,2.3.28)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Improper Input Validation",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:L/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.701000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 6.1,
+        "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nApache Struts 2.x before 2.3.25 does not sanitize text in the Locale object constructed by I18NInterceptor, which might allow remote attackers to conduct cross-site scripting (XSS) attacks via unspecified vectors involving language display.\n\n## Details\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\r\n\r\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\r\n\r\nֿInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\r\n\r\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\r\n \r\nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \r\n\r\n### Types of attacks\r\nThere are a few methods by which XSS can be manipulated:\r\n\r\n|Type|Origin|Description|\r\n|--|--|--|\r\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\r\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \r\n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\r\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\r\n\r\n### Affected environments\r\nThe following environments are susceptible to an XSS attack:\r\n\r\n* Web servers\r\n* Application servers\r\n* Web application environments\r\n\r\n### How to prevent\r\nThis section describes the top best practices designed to specifically protect your code: \r\n\r\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \r\n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \r\n* Give users the option to disable client-side scripts.\r\n* Redirect invalid requests.\r\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\r\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\r\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-2162)",
+        "disclosureTime": "2016-03-16T07:51:26.242000Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.25"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30800",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-2162"
+          ],
+          "CWE": [
+            "CWE-79"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2019-06-02T10:19:50.776439Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-03-16T07:51:26.242000Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/fc2179cf1ac9fbfb61e3430fa88b641d87253327"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-2162"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2,2.3.25)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Cross-site Scripting (XSS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.713000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nApache Struts 2.0.0 through 2.3.24.1 does not properly cache method references when used with OGNL before 3.0.12, which allows remote attackers to cause a denial of service (block access to a web site) via unspecified vectors.\n\n## References\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093)",
+        "disclosureTime": "2016-06-02T02:16:48.918000Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30801",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-3093"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2018-11-18T11:50:44.461613Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-02T02:16:48.918000Z",
+        "references": [
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3093"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2,2.3.24.1]"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Improper Input Validation",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.724000Z",
+        "credit": [
+          "Takeshi Terada"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Access Restriction Bypass. It allows remote attackers to bypass intended access restrictions and conduct redirection attacks via a crafted request.\n## Remediation\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433)\n",
+        "disclosureTime": "2016-06-21T01:33:07Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30802",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4433"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2018-11-18T11:50:44.463554Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-21T01:33:07Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/b28b78c062f0bf3c79793a25aab8c9b6c12bce6e"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4433"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20,2.3.28.1]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Access Restriction Bypass",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.738000Z",
+        "credit": [
+          "Alvaro Munoz"
+        ],
+        "cvssScore": 8.8,
+        "description": "## Overview\n[`org.apache.struts.xwork:xwork-core`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22xwork-core%22)\nAffected versions of the package are vulnerable to Remote code Execution. The Apache Struts frameworks when forced, performs double evaluation of attributes' values assigned to certain tags so it is possible to pass in a value that will be evaluated again when a tag's attributes will be rendered.\n\n## References\n- [Apache Security Advisory](https://struts.apache.org/docs/s2-036.html)\n",
+        "disclosureTime": "2016-11-14T07:48:03.440000Z",
+        "exploit": "Not Defined",
+        "fixedIn": [],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30803",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4461"
+          ],
+          "CWE": [
+            "CWE-264"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2018-11-18T11:50:44.465500Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-11-14T07:48:03.440000Z",
+        "references": [
+          {
+            "title": "Apache Security Advisory",
+            "url": "https://struts.apache.org/docs/s2-036.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.2.1,2.3.28.1]"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Arbitrary Code Execution",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:23.751000Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS). The URLValidator class allows remote attackers to cause a denial of service via a null value for a URL field.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\n\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\n\nLet’s take the following regular expression as an example:\n```js\nregex = /A(B|C+)+D/\n```\n\nThis regular expression accomplishes the following:\n- `A` The string must start with the letter 'A'\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\n- `D` Finally, we ensure this section of the string ends with a 'D'\n\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\n\nIt most cases, it doesn't take very long for a regex engine to find a match:\n\n```bash\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\n0.04s user 0.01s system 95% cpu 0.052 total\n\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\n1.79s user 0.02s system 99% cpu 1.812 total\n```\n\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\n\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\n\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\n1. CCC\n2. CC+C\n3. C+CC\n4. C+C+C.\n\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\n\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\n\n| String | Number of C's | Number of steps |\n| -------|-------------:| -----:|\n| ACCCX | 3 | 38\n| ACCCCX | 4 | 71\n| ACCCCCX | 5 | 136\n| ACCCCCCCCCCCCCCX | 14 | 65,553\n\n\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.29 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152)\n- [GitHub Commit](https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465)\n",
+        "disclosureTime": "2016-06-20T07:45:43Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.29"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-30804",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-4465"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2020-06-12T14:37:00.906498Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-06-20T07:45:43Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/a0fdca138feec2c2e94eb75ca1f8b76678b4d152"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/eccc31ebce5430f9e91b9684c63eaaf885e603f9"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-4465"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20, 2.3.29)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H/E:H/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2019-07-16T11:38:49.236917Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Command Injection. When Dynamic Method Invocation was enabled, a remote attackers could execute arbitrary code via the prefix method, related to chained expressions.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.20.2, 2.3.24.2, 2.3.28.1 or higher.\n## References\n- [Exploit DB](https://exploit-db.com/exploits/39756)\n- [GitHub Commit](https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081)\n",
+        "disclosureTime": "2016-04-22T04:32:51Z",
+        "exploit": "High",
+        "fixedIn": [
+          "2.3.20.2",
+          "2.3.24.2",
+          "2.3.28.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-451611",
+        "identifiers": {
+          "CVE": [
+            "CVE-2016-3081"
+          ],
+          "CWE": [
+            "CWE-77"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2020-06-12T14:37:05.096103Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-04-22T04:32:51Z",
+        "references": [
+          {
+            "title": "Exploit DB",
+            "url": "https://exploit-db.com/exploits/39756"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/f238cf4f1091be19fbcfd086b042c86a1bcaa7fc"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2016-3081"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.0.0, 2.3.20.2)",
+            "[2.3.24, 2.3.24.2)",
+            "[2.3.28, 2.3.28.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Command Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2019-10-27T13:46:24.359760Z",
+        "credit": [
+          "Jasper Rosenberg"
+        ],
+        "cvssScore": 7.3,
+        "description": "## Overview\n[org.apache.struts.xwork:xwork-core](https://mvnrepository.com/artifact/org.apache.struts.xwork/xwork-core) is a generic command pattern framework. It forms the core of Struts 2.\n\nAffected versions of this package are vulnerable to Insecure Defaults. The default exclude patterns (excludeParams) allow remote attackers to \"compromise internal state of an application\" via unspecified vectors.\n## Remediation\nUpgrade `org.apache.struts.xwork:xwork-core` to version 2.3.20.1 or higher.\n## References\n- [GitHub Commit](https://github.com/apache/struts/commit/5ebc0643b55d728a6713a82559a594d875452cd8)\n- [GitHub Commit](https://github.com/apache/struts/commit/d832747d647df343ed07a58b1b5e540a05a4d51b)\n- [Jira Issue](https://issues.apache.org/jira/browse/WW-4486)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1831)\n- [Struts Security Advisory](https://struts.apache.org/docs/s2-024.html)\n- [Vulnerability Summary](http://struts.apache.org/docs/s2-024.html)\n",
+        "disclosureTime": "2015-05-11T16:51:55Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.3.20.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGAPACHESTRUTSXWORK-474418",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-1831"
+          ],
+          "CWE": [
+            "CWE-453"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "xwork-core",
+          "groupId": "org.apache.struts.xwork"
+        },
+        "modificationTime": "2020-06-12T14:36:54.927561Z",
+        "moduleName": "org.apache.struts.xwork:xwork-core",
+        "packageManager": "maven",
+        "packageName": "org.apache.struts.xwork:xwork-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2015-05-11T16:51:55Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/5ebc0643b55d728a6713a82559a594d875452cd8"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/apache/struts/commit/d832747d647df343ed07a58b1b5e540a05a4d51b"
+          },
+          {
+            "title": "Jira Issue",
+            "url": "https://issues.apache.org/jira/browse/WW-4486"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-1831"
+          },
+          {
+            "title": "Struts Security Advisory",
+            "url": "https://struts.apache.org/docs/s2-024.html"
+          },
+          {
+            "title": "Vulnerability Summary",
+            "url": "http://struts.apache.org/docs/s2-024.html"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[2.3.20,2.3.20.1)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Insecure Defaults",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.apache.struts:struts2-core@2.3.20",
+          "org.apache.struts.xwork:xwork-core@2.3.20"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.apache.struts.xwork:xwork-core",
+        "version": "2.3.20"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N/E:U/RL:O/RC:U",
+        "alternativeIds": [],
+        "creationTime": "2020-11-19T16:51:52.251545Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 8.2,
+        "description": "## Overview\n[org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) is a library providing Object/Relational Mapping (ORM) support to applications, libraries, and frameworks.\n\nAffected versions of this package are vulnerable to SQL Injection. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SQL comments of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks. The highest threat from this vulnerability is to data confidentiality and integrity.\n## Remediation\nUpgrade `org.hibernate:hibernate-core` to version 5.4.24.Final or higher.\n## References\n- [GitHub Commit](https://github.com/hibernate/hibernate-orm/commit/59fede7acaaa1579b561407aefa582311f7ebe78)\n- [Redhat CVE Details](https://access.redhat.com/security/cve/cve-2020-25638)\n",
+        "disclosureTime": "2020-11-19T16:51:45Z",
+        "exploit": "Unproven",
+        "fixedIn": [
+          "5.4.24.Final"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "SelectStatementBuilder",
+              "filePath": "org/hibernate/loader/plan/exec/query/internal/SelectStatementBuilder.java",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "Delete",
+              "filePath": "org/hibernate/sql/Delete.java",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "Insert",
+              "filePath": "org/hibernate/sql/Insert.java",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "InsertSelect",
+              "filePath": "org/hibernate/sql/InsertSelect.java",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "QuerySelect",
+              "filePath": "org/hibernate/sql/QuerySelect.java",
+              "functionName": "toQueryString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "Select",
+              "filePath": "org/hibernate/sql/Select.java",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "SimpleSelect",
+              "filePath": "org/hibernate/sql/SimpleSelect.java",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "Update",
+              "filePath": "org/hibernate/sql/Update.java",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.hibernate.loader.plan.exec.query.internal.SelectStatementBuilder",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.hibernate.sql.Delete",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.hibernate.sql.Insert",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.hibernate.sql.InsertSelect",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.hibernate.sql.QuerySelect",
+              "functionName": "toQueryString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.hibernate.sql.Select",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.hibernate.sql.SimpleSelect",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.hibernate.sql.Update",
+              "functionName": "toStatementString"
+            },
+            "version": [
+              "[,5.4.24.Final)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGHIBERNATE-1041788",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-25638"
+          ],
+          "CWE": [
+            "CWE-89"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "hibernate-core",
+          "groupId": "org.hibernate"
+        },
+        "modificationTime": "2020-12-14T08:10:39.297101Z",
+        "moduleName": "org.hibernate:hibernate-core",
+        "packageManager": "maven",
+        "packageName": "org.hibernate:hibernate-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-11-19T16:57:14.572204Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-orm/commit/59fede7acaaa1579b561407aefa582311f7ebe78"
+          },
+          {
+            "title": "Redhat CVE Details",
+            "url": "https://access.redhat.com/security/cve/cve-2020-25638"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,5.4.24.Final)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "SQL Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-core@4.3.7.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate:hibernate-core",
+        "version": "4.3.7.Final"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-07-15T13:53:15.331818Z",
+        "credit": [
+          "Gail Badner"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\n[org.hibernate:hibernate-core](https://github.com/hibernate/hibernate-orm) is a library providing Object/Relational Mapping (ORM) support to applications, libraries, and frameworks.\n\nAffected versions of this package are vulnerable to SQL Injection. A SQL injection in the implementation of the JPA Criteria API can permit unsanitized literals when a literal is used in the SELECT or GROUP BY parts of the query. This flaw could allow an attacker to access unauthorized information or possibly conduct further attacks.\n## Remediation\nUpgrade `org.hibernate:hibernate-core` to version 5.3.18.Final, 5.4.18.Final or higher.\n## References\n- [GitHub Pull Request](https://github.com/hibernate/hibernate-orm/pull/3438)\n- [Jira Ticket](https://hibernate.atlassian.net/browse/HHH-14077)\n",
+        "disclosureTime": "2020-06-18T13:46:30Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "5.3.18.Final",
+          "5.4.18.Final"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "LiteralExpression",
+              "filePath": "org/hibernate/query/criteria/internal/expression/LiteralExpression.java",
+              "functionName": "renderProjection"
+            },
+            "version": [
+              "[5.1.18.Final ,5.4.18.Final)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.hibernate.query.criteria.internal.expression.LiteralExpression",
+              "functionName": "renderProjection"
+            },
+            "version": [
+              "[5.1.18.Final ,5.4.18.Final)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGHIBERNATE-584563",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-14900"
+          ],
+          "CWE": [
+            "CWE-89"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "hibernate-core",
+          "groupId": "org.hibernate"
+        },
+        "modificationTime": "2020-08-12T13:41:12.343011Z",
+        "moduleName": "org.hibernate:hibernate-core",
+        "packageManager": "maven",
+        "packageName": "org.hibernate:hibernate-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-07-15T16:40:12Z",
+        "references": [
+          {
+            "title": "GitHub Pull Request",
+            "url": "https://github.com/hibernate/hibernate-orm/pull/3438"
+          },
+          {
+            "title": "Jira Ticket",
+            "url": "https://hibernate.atlassian.net/browse/HHH-14077"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,5.3.18.Final)",
+            "[5.4.0.Final, 5.4.18.Final)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "SQL Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-core@4.3.7.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate:hibernate-core",
+        "version": "4.3.7.Final"
+      },
+      {
+        "license": "LGPL-2.0",
+        "semver": {
+          "vulnerable": [
+            "[3.3.0.CR1, 5.3.1.Final)"
+          ]
+        },
+        "id": "snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0",
+        "type": "license",
+        "packageManager": "maven",
+        "language": "java",
+        "packageName": "org.hibernate:hibernate-core",
+        "title": "LGPL-2.0 license",
+        "description": "LGPL-2.0 license",
+        "publicationTime": "2021-01-24T02:22:13.369Z",
+        "creationTime": "2021-01-24T02:22:13.369Z",
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.0.txt",
+        "severity": "medium",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-core@4.3.7.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate:hibernate-core",
+        "version": "4.3.7.Final"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:53Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to JSM bypass via ReflectionHelper. ReflectionHelper (`org.hibernate.validator.util.ReflectionHelper`) in Hibernate Validator 4.1.0 before 4.2.1, 4.3.x before 4.3.2, and 5.x before 5.1.2 allows attackers to bypass Java Security Manager (JSM) restrictions and execute restricted reflection calls via a crafted application.\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 4.3.2.Final, 5.1.2.Final or higher.\n## References\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/2c95d4ea0ef20977be249e31a4a4f4f4f71c945d)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/67fdff14831c035c25e098fe14bd86523d17f726)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/7e7131939a4361a7cad3e77ab89a8462132c561c)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/c489416f699a46859c134796b3ccfea41ef3ce52)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/c9525ca544b1281e2b7c7347e86e87c86dc1dc6e)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/e8c42b689df8c6752d635d02c6518da3fece3870)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/f97c2021a03c825abdeca1692f5be51e77e76a8f)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/fd4eaed7fb930db6a5e4c03742b4b3adcfecc90e)\n- [Jira Issue](https://hibernate.atlassian.net/browse/HV-912)\n- [Redhat Bugzilla](https://bugzilla.redhat.com/CVE-2014-3558)\n",
+        "disclosureTime": "2014-07-17T16:51:53Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.3.2.Final",
+          "5.1.2.Final"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGHIBERNATE-30098",
+        "identifiers": {
+          "CVE": [
+            "CVE-2014-3558"
+          ],
+          "CWE": [
+            "CWE-592"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "hibernate-validator",
+          "groupId": "org.hibernate"
+        },
+        "modificationTime": "2020-07-06T14:44:00.410984Z",
+        "moduleName": "org.hibernate:hibernate-validator",
+        "packageManager": "maven",
+        "packageName": "org.hibernate:hibernate-validator",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2014-07-17T16:51:53Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/2c95d4ea0ef20977be249e31a4a4f4f4f71c945d"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/67fdff14831c035c25e098fe14bd86523d17f726"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/7e7131939a4361a7cad3e77ab89a8462132c561c"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/c489416f699a46859c134796b3ccfea41ef3ce52"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/c9525ca544b1281e2b7c7347e86e87c86dc1dc6e"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/e8c42b689df8c6752d635d02c6518da3fece3870"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/f97c2021a03c825abdeca1692f5be51e77e76a8f"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/fd4eaed7fb930db6a5e4c03742b4b3adcfecc90e"
+          },
+          {
+            "title": "Jira Issue",
+            "url": "https://hibernate.atlassian.net/browse/HV-912"
+          },
+          {
+            "title": "Redhat Bugzilla",
+            "url": "https://bugzilla.redhat.com/CVE-2014-3558"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[4.1.0.Beta1, 4.3.2.Final)",
+            "[5.0.0.Final,5.1.2.Final)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "JSM bypass via ReflectionHelper",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-validator@4.3.1.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate:hibernate-validator",
+        "version": "4.3.1.Final"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:L/A:N",
+        "alternativeIds": [],
+        "creationTime": "2020-05-05T12:05:58.541980Z",
+        "credit": [
+          "Alvaro Muñoz"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to Improper Input Validation. A bug in the message interpolation processor enables invalid EL expressions to be evaluated as if they were valid. This flaw allows attackers to bypass input sanitation (escaping, stripping) controls that developers may have put in place when handling user-controlled data in error messages.\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 6.0.19.Final, 6.1.3.Final or higher.\n## References\n- [GitHub PR](https://github.com/hibernate/hibernate-validator/pull/1071)\n- [Jira Issue](https://hibernate.atlassian.net/browse/HV-1758)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1805501)\n",
+        "disclosureTime": "2020-05-05T00:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "6.0.19.Final",
+          "6.1.3.Final"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "ValidatorImpl",
+              "filePath": "org/hibernate/validator/internal/engine/ValidatorImpl.java",
+              "functionName": "validate"
+            },
+            "version": [
+              "[,6.0.19.Final)",
+              "[6.1.0,6.1.3.Final)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.hibernate.validator.internal.engine.ValidatorImpl",
+              "functionName": "validate"
+            },
+            "version": [
+              "[,6.0.19.Final)",
+              "[6.1.0,6.1.3.Final)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGHIBERNATE-568162",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-10693"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "hibernate-validator",
+          "groupId": "org.hibernate"
+        },
+        "modificationTime": "2020-07-06T10:04:57.507792Z",
+        "moduleName": "org.hibernate:hibernate-validator",
+        "packageManager": "maven",
+        "packageName": "org.hibernate:hibernate-validator",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-05-05T16:32:46Z",
+        "references": [
+          {
+            "title": "GitHub PR",
+            "url": "https://github.com/hibernate/hibernate-validator/pull/1071"
+          },
+          {
+            "title": "Jira Issue",
+            "url": "https://hibernate.atlassian.net/browse/HV-1758"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1805501"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,6.0.19.Final)",
+            "[6.1.0,6.1.3.Final)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Improper Input Validation",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-validator@4.3.1.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate:hibernate-validator",
+        "version": "4.3.1.Final"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:N/A:N/E:U/RL:O/RC:R",
+        "alternativeIds": [],
+        "creationTime": "2020-05-14T16:07:06.897969Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 6.5,
+        "description": "## Overview\n[org.hibernate:hibernate-validator](https://mvnrepository.com/artifact/org.hibernate/hibernate-validator) is a Hibernate Validator Engine Relocation Artifact.\n\nAffected versions of this package are vulnerable to Cross-site Scripting (XSS). The `SafeHtml` validator annotation fails to properly sanitize payloads consisting of potentially malicious code in HTML comments and instructions.\n## Details\n\nA cross-site scripting attack occurs when the attacker tricks a legitimate web-based application or site to accept a request as originating from a trusted source.\n\nThis is done by escaping the context of the web application; the web application then delivers that data to its users along with other trusted dynamic content, without validating it. The browser unknowingly executes malicious script on the client side (through client-side languages; usually JavaScript or HTML)  in order to perform actions that are otherwise typically blocked by the browser’s Same Origin Policy.\n\nInjecting malicious code is the most prevalent manner by which XSS is exploited; for this reason, escaping characters in order to prevent this manipulation is the top method for securing code against this vulnerability.\n\nEscaping means that the application is coded to mark key characters, and particularly key characters included in user input, to prevent those characters from being interpreted in a dangerous context. For example, in HTML, `<` can be coded as  `&lt`; and `>` can be coded as `&gt`; in order to be interpreted and displayed as themselves in text, while within the code itself, they are used for HTML tags. If malicious content is injected into an application that escapes special characters and that malicious content uses `<` and `>` as HTML tags, those characters are nonetheless not interpreted as HTML tags by the browser if they’ve been correctly escaped in the application code and in this way the attempted attack is diverted.\n \nThe most prominent use of XSS is to steal cookies (source: OWASP HttpOnly) and hijack user sessions, but XSS exploits have been used to expose sensitive information, enable access to privileged services and functionality and deliver malware. \n\n### Types of attacks\nThere are a few methods by which XSS can be manipulated:\n\n|Type|Origin|Description|\n|--|--|--|\n|**Stored**|Server|The malicious code is inserted in the application (usually as a link) by the attacker. The code is activated every time a user clicks the link.|\n|**Reflected**|Server|The attacker delivers a malicious link externally from the vulnerable web site application to a user. When clicked, malicious code is sent to the vulnerable web site, which reflects the attack back to the user’s browser.| \n|**DOM-based**|Client|The attacker forces the user’s browser to render a malicious page. The data in the page itself delivers the cross-site scripting data.|\n|**Mutated**| |The attacker injects code that appears safe, but is then rewritten and modified by the browser, while parsing the markup. An example is rebalancing unclosed quotation marks or even adding quotation marks to unquoted parameters.|\n\n### Affected environments\nThe following environments are susceptible to an XSS attack:\n\n* Web servers\n* Application servers\n* Web application environments\n\n### How to prevent\nThis section describes the top best practices designed to specifically protect your code: \n\n* Sanitize data input in an HTTP request before reflecting it back, ensuring all data is validated, filtered or escaped before echoing anything back to the user, such as the values of query parameters during searches. \n* Convert special characters such as `?`, `&`, `/`, `<`, `>` and spaces to their respective HTML or URL encoded equivalents. \n* Give users the option to disable client-side scripts.\n* Redirect invalid requests.\n* Detect simultaneous logins, including those from two separate IP addresses, and invalidate those sessions.\n* Use and enforce a Content Security Policy (source: Wikipedia) to disable any features that might be manipulated for an XSS attack.\n* Read the documentation for any of the libraries referenced in your code to understand which elements allow for embedded HTML.\n\n## Remediation\nUpgrade `org.hibernate:hibernate-validator` to version 6.0.18.Final, 6.1.0.Final or higher.\n## References\n- [Apache Security Advisory](https://lists.apache.org/thread.html/r87b7e2d22982b4ca9f88f5f4f22a19b394d2662415b233582ed22ebf@%3Cnotifications.accumulo.apache.org%3E)\n- [GitHub Commit](https://github.com/hibernate/hibernate-validator/commit/124b7dd6d9a4ad24d4d49f74701f05a13e56ceee)\n- [Hibernator Security Release Blog](https://in.relation.to/2019/11/20/hibernate-validator-610-6018-released/)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-10219)\n",
+        "disclosureTime": "2018-10-18T14:55:21Z",
+        "exploit": "Unproven",
+        "fixedIn": [
+          "6.0.18.Final",
+          "6.1.0.Final"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "SafeHtmlValidator",
+              "filePath": "org/hibernate/validator/internal/constraintvalidators/hv/SafeHtmlValidator.java",
+              "functionName": "getFragmentAsDocument"
+            },
+            "version": [
+              "[,6.0.18.Final)",
+              "[6.1.0.Alpha1,6.1.0.Final)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.hibernate.validator.internal.constraintvalidators.hv.SafeHtmlValidator",
+              "functionName": "getFragmentAsDocument"
+            },
+            "version": [
+              "[,6.0.18.Final)",
+              "[6.1.0.Alpha1,6.1.0.Final)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGHIBERNATE-569100",
+        "identifiers": {
+          "CVE": [
+            "CVE-2019-10219"
+          ],
+          "CWE": [
+            "CWE-79"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "hibernate-validator",
+          "groupId": "org.hibernate"
+        },
+        "modificationTime": "2020-07-06T10:09:01.558495Z",
+        "moduleName": "org.hibernate:hibernate-validator",
+        "packageManager": "maven",
+        "packageName": "org.hibernate:hibernate-validator",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-01-09T14:55:12Z",
+        "references": [
+          {
+            "title": "Apache Security Advisory",
+            "url": "https://lists.apache.org/thread.html/r87b7e2d22982b4ca9f88f5f4f22a19b394d2662415b233582ed22ebf@%3Cnotifications.accumulo.apache.org%3E"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/hibernate/hibernate-validator/commit/124b7dd6d9a4ad24d4d49f74701f05a13e56ceee"
+          },
+          {
+            "title": "Hibernator Security Release Blog",
+            "url": "https://in.relation.to/2019/11/20/hibernate-validator-610-6018-released/"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2019-10219"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,6.0.18.Final)",
+            "[6.1.0.Alpha1,6.1.0.Final)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Cross-site Scripting (XSS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-validator@4.3.1.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate:hibernate-validator",
+        "version": "4.3.1.Final"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-09-18T14:36:44.859594Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 8.6,
+        "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to Improper Input Validation. The protections against Reflected File Download attacks from CVE-2015-5211 may be bypassed depending on the browser used through the use of a `jsessionid` path parameter.\n## Remediation\nUpgrade `org.springframework:spring-web` to version 4.3.29.RELEASE, 5.0.19.RELEASE, 5.1.18.RELEASE, 5.2.9.RELEASE or higher.\n## References\n- [CVE-2015-5211](https://tanzu.vmware.com/security/cve-2015-5211)\n- [Pivotal Security Advisory](https://pivotal.io/security/cve-2020-5421)\n",
+        "disclosureTime": "2020-09-18T14:23:55Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "4.3.29.RELEASE",
+          "5.0.19.RELEASE",
+          "5.1.18.RELEASE",
+          "5.2.9.RELEASE"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "WebUtils",
+              "filePath": "org/springframework/web/util/WebUtils.java",
+              "functionName": "parseMatrixVariables"
+            },
+            "version": [
+              "[3.2.0.RELEASE,4.3.29.RELEASE)",
+              "[5.0.0.RELEASE, 5.0.19.RELEASE)",
+              "[5.1.0.RELEASE, 5.1.18.RELEASE)",
+              "[5.2.0.RELEASE, 5.2.9.RELEASE)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.springframework.web.util.WebUtils",
+              "functionName": "parseMatrixVariables"
+            },
+            "version": [
+              "[3.2.0.RELEASE,4.3.29.RELEASE)",
+              "[5.0.0.RELEASE, 5.0.19.RELEASE)",
+              "[5.1.0.RELEASE, 5.1.18.RELEASE)",
+              "[5.2.0.RELEASE, 5.2.9.RELEASE)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-1009832",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-5421"
+          ],
+          "CWE": [
+            "CWE-20"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "spring-web",
+          "groupId": "org.springframework"
+        },
+        "modificationTime": "2020-11-01T15:06:12.285684Z",
+        "moduleName": "org.springframework:spring-web",
+        "packageManager": "maven",
+        "packageName": "org.springframework:spring-web",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2020-09-18T16:17:53Z",
+        "references": [
+          {
+            "title": "CVE-2015-5211",
+            "url": "https://tanzu.vmware.com/security/cve-2015-5211"
+          },
+          {
+            "title": "Pivotal Security Advisory",
+            "url": "https://pivotal.io/security/cve-2020-5421"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[3.2.0.RELEASE,4.3.29.RELEASE)",
+            "[5.0.0.RELEASE, 5.0.19.RELEASE)",
+            "[5.1.0.RELEASE, 5.1.18.RELEASE)",
+            "[5.2.0.RELEASE, 5.2.9.RELEASE)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Improper Input Validation",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.springframework:spring-web@3.2.6.RELEASE"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.springframework:spring-web",
+        "version": "3.2.6.RELEASE"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:52Z",
+        "credit": [
+          "Unknown"
+        ],
+        "cvssScore": 8.8,
+        "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to XML External Entity (XXE) Injection. This is due to not disabling the resolution of URI references by default in a DTD declaration. This occurs only when processing user provided XML documents.\n\n## Details\nXXE Injection is a type of attack against an application that parses XML input.\nXML is a markup language that defines a set of rules for encoding documents in a format that is both human-readable and machine-readable. By default, many XML processors allow specification of an external entity, a URI that is dereferenced and evaluated during XML processing. When an XML document is being parsed, the parser can make a request and include the content at the specified URI inside of the XML document.\n\nAttacks can include disclosing local files, which may contain sensitive data such as passwords or private user data, using file: schemes or relative paths in the system identifier.\n\nFor example, below is a sample XML document, containing an XML element- username.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n   <username>John</username>\n</xml>\n```\n\nAn external XML entity - `xxe`, is defined using a system identifier and present within a DOCTYPE header. These entities can access local or remote content. For example the below code contains an external XML entity that would fetch the content of  `/etc/passwd` and display it to the user rendered by `username`.\n\n```xml\n<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>\n<!DOCTYPE foo [\n   <!ENTITY xxe SYSTEM \"file:///etc/passwd\" >]>\n   <username>&xxe;</username>\n</xml>\n```\n\nOther XXE Injection attacks can access local resources that may not stop returning data, possibly impacting application availability and leading to Denial of Service.\n\n## Remediation\nUpgrade `org.springframework:spring-web` to version 3.2.9.RELEASE, 4.0.5.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/8e096aeef55287dc829484996c9330cf755891a1)\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/c6503ebbf7c9e21ff022c58706dbac5417b2b5eb)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/16390)\n- [Pivotal Security](http://www.gopivotal.com/security/cve-2014-0225)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0225)\n",
+        "disclosureTime": "2016-12-25T16:51:52Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.2.9.RELEASE",
+          "4.0.5.RELEASE"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "SourceHttpMessageConverter",
+              "filePath": "org/springframework/http/converter/xml/SourceHttpMessageConverter.java",
+              "functionName": "readDOMSource"
+            },
+            "version": [
+              "[3,3.2.8.RELEASE]",
+              "[4,4.0.4.RELEASE]"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "SourceHttpMessageConverter",
+              "filePath": "org/springframework/http/converter/xml/SourceHttpMessageConverter.java",
+              "functionName": "readSAXSource"
+            },
+            "version": [
+              "[3,3.2.8.RELEASE]",
+              "[4,4.0.4.RELEASE]"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.springframework.http.converter.xml.SourceHttpMessageConverter",
+              "functionName": "readDOMSource"
+            },
+            "version": [
+              "[3,3.2.8.RELEASE]",
+              "[4,4.0.4.RELEASE]"
+            ]
+          },
+          {
+            "functionId": {
+              "className": "org.springframework.http.converter.xml.SourceHttpMessageConverter",
+              "functionName": "readSAXSource"
+            },
+            "version": [
+              "[3,3.2.8.RELEASE]",
+              "[4,4.0.4.RELEASE]"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30163",
+        "identifiers": {
+          "CVE": [
+            "CVE-2014-0225"
+          ],
+          "CWE": [
+            "CWE-611"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "spring-web",
+          "groupId": "org.springframework"
+        },
+        "modificationTime": "2020-06-12T14:37:03.352101Z",
+        "moduleName": "org.springframework:spring-web",
+        "packageManager": "maven",
+        "packageName": "org.springframework:spring-web",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-12-25T16:51:52Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/8e096aeef55287dc829484996c9330cf755891a1"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/c6503ebbf7c9e21ff022c58706dbac5417b2b5eb"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/spring-projects/spring-framework/issues/16390"
+          },
+          {
+            "title": "Pivotal Security",
+            "url": "http://www.gopivotal.com/security/cve-2014-0225"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=CVE-2014-0225"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[3.0.0.RELEASE,3.2.9.RELEASE)",
+            "[4.0.0.RELEASE,4.0.5.RELEASE)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "XML External Entity (XXE) Injection",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.springframework:spring-web@3.2.6.RELEASE"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.springframework:spring-web",
+        "version": "3.2.6.RELEASE"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:55Z",
+        "credit": [
+          "Toshiaki Maki"
+        ],
+        "cvssScore": 5.5,
+        "description": "## Overview\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) is a package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\nAffected versions of this package are vulnerable to Denial of Service (DoS). It does not properly process inline DTD declarations when DTD is not entirely disabled, which allows remote attackers to cause a denial of service (memory consumption and out-of-memory errors) via a crafted XML file.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libraries.\n\nTwo common types of DoS vulnerabilities:\n\n* High CPU/Memory Consumption- An attacker sending crafted requests that could cause the system to take a disproportionate amount of time to process. For example, [commons-fileupload:commons-fileupload](SNYK-JAVA-COMMONSFILEUPLOAD-30082).\n\n* Crash - An attacker sending crafted requests that could cause the system to crash. For Example,  [npm `ws` package](https://snyk.io/vuln/npm:ws:20171108)\n\n## Remediation\nUpgrade `org.springframework:spring-web` to version 3.2.14.RELEASE, 4.1.7.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/5a711c05ec750f069235597173084c2ee796242)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/17727)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3192)\n- [Pivotal Security](http://pivotal.io/security/cve-2015-3192)\n",
+        "disclosureTime": "2015-10-16T05:57:41Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.2.14.RELEASE",
+          "4.1.7.RELEASE"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30164",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-3192"
+          ],
+          "CWE": [
+            "CWE-119"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "spring-web",
+          "groupId": "org.springframework"
+        },
+        "modificationTime": "2020-06-12T14:36:56.172880Z",
+        "moduleName": "org.springframework:spring-web",
+        "packageManager": "maven",
+        "packageName": "org.springframework:spring-web",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-12-25T16:51:55Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/5a711c05ec750f069235597173084c2ee796242"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/spring-projects/spring-framework/issues/17727"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-3192"
+          },
+          {
+            "title": "Pivotal Security",
+            "url": "http://pivotal.io/security/cve-2015-3192"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[3.2.0.RELEASE, 3.2.14.RELEASE)",
+            "[4.0.0.RELEASE, 4.1.7.RELEASE)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.springframework:spring-web@3.2.6.RELEASE"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.springframework:spring-web",
+        "version": "3.2.6.RELEASE"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:H",
+        "alternativeIds": [],
+        "creationTime": "2016-12-25T16:51:56Z",
+        "credit": [
+          "Alvaro Muñoz"
+        ],
+        "cvssScore": 8.6,
+        "description": "## Overview\n\n[org.springframework:spring-web](https://github.com/spring-projects/spring-framework) package that provides a comprehensive programming and configuration model for modern Java-based enterprise applications - on any kind of deployment platform.\n\n\nAffected versions of this package are vulnerable to Reflected File Download\nvia a crafted URL with a batch script extension, resulting in the response being downloaded rather than rendered.\n\n## Remediation\n\nUpgrade `org.springframework:spring-web` to version 3.2.15.RELEASE, 4.1.8.RELEASE, 4.2.2.RELEASE or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/03f547eb9868f48f44d59b56067d4ac4740672c3)\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/2bd1daa75ee0b8ec33608ca6ab065ef3e1815543)\n\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/a95c3d820dbc4c3ae752f1b3ee22ee860b162402)\n\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/18124)\n\n- [Oren Hafif Blog](https://www.trustwave.com/Resources/SpiderLabs-Blog/Reflected-File-Download---A-New-Web-Attack-Vector/)\n\n- [Pivotal Security](http://pivotal.io/security/cve-2015-5211)\n\n- [RedHat CVE Database](https://access.redhat.com/security/cve/cve-2015-5211)\n",
+        "disclosureTime": "2015-10-15T16:51:56Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.2.15.RELEASE",
+          "4.1.8.RELEASE",
+          "4.2.2.RELEASE"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-30165",
+        "identifiers": {
+          "CVE": [
+            "CVE-2015-5211"
+          ],
+          "CWE": [
+            "CWE-494"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "spring-web",
+          "groupId": "org.springframework"
+        },
+        "modificationTime": "2019-09-19T11:19:29.640092Z",
+        "moduleName": "org.springframework:spring-web",
+        "packageManager": "maven",
+        "packageName": "org.springframework:spring-web",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2016-12-25T16:51:56Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/03f547eb9868f48f44d59b56067d4ac4740672c3"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/2bd1daa75ee0b8ec33608ca6ab065ef3e1815543"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/a95c3d820dbc4c3ae752f1b3ee22ee860b162402"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/spring-projects/spring-framework/issues/18124"
+          },
+          {
+            "title": "Oren Hafif Blog",
+            "url": "https://www.trustwave.com/Resources/SpiderLabs-Blog/Reflected-File-Download---A-New-Web-Attack-Vector/"
+          },
+          {
+            "title": "Pivotal Security",
+            "url": "http://pivotal.io/security/cve-2015-5211"
+          },
+          {
+            "title": "RedHat CVE Database",
+            "url": "https://access.redhat.com/security/cve/cve-2015-5211"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[3.2.0.RELEASE, 3.2.15.RELEASE)",
+            "[4.0.0.RELEASE, 4.1.8.RELEASE)",
+            "[4.2.0.RELEASE, 4.2.2.RELEASE)"
+          ]
+        },
+        "severity": "high",
+        "severityWithCritical": "high",
+        "title": "Reflected File Download",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.springframework:spring-web@3.2.6.RELEASE"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.springframework:spring-web",
+        "version": "3.2.6.RELEASE"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:L/I:L/A:L",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:31.538000Z",
+        "credit": [
+          "Spase Markovski"
+        ],
+        "cvssScore": 6.3,
+        "description": "## Overview\r\n[`org.springframework:spring-web`](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22spring-web%22)\r\nAffected versions of this package do not disable external entity resolution, which allows remote attackers to read arbitrary files, cause a denial of service and conduct CSRF attacks via crafted XML, aka an XML External Entity (XXE) issue.  \r\n\r\n**NOTE:** this vulnerability exists because of an incomplete fix for [CVE-2013-4152](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-31330), [CVE-2013-7315](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30162), and [CVE-2013-6429](https://snyk.io/vuln/SNYK-JAVA-ORGSPRINGFRAMEWORK-30160).\r\n\r\n## References\r\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0054)",
+        "disclosureTime": "2014-04-17T14:55:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.2.8.RELEASE",
+          "4.0.2.RELEASE"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-31331",
+        "identifiers": {
+          "CVE": [
+            "CVE-2014-0054"
+          ],
+          "CWE": [
+            "CWE-352"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "spring-web",
+          "groupId": "org.springframework"
+        },
+        "modificationTime": "2019-09-16T14:38:30.980318Z",
+        "moduleName": "org.springframework:spring-web",
+        "packageManager": "maven",
+        "packageName": "org.springframework:spring-web",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2014-06-06T21:43:43Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/edba32b3093703d5e9ed42b5b8ec23ecc1998398%23diff-1f3f1d5cdab9ac92d1ca5ec7def8f131"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/fb0683c066e74e9667d6cd8c5fa01f674c68c3be%23diff-1f3f1d5cdab9ac92d1ca5ec7def8f131"
+          },
+          {
+            "title": "Jira Issue",
+            "url": "https://jira.spring.io/browse/SPR-11376"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-0054"
+          },
+          {
+            "title": "Pivotal Security",
+            "url": "http://www.pivotal.io/security/cve-2014-0054"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[3.0.0.RELEASE,3.2.8.RELEASE)",
+            "[4.0.0.RELEASE,4.0.2.RELEASE)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Cross-site Request Forgery (CSRF)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.springframework:spring-web@3.2.6.RELEASE"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.springframework:spring-web",
+        "version": "3.2.6.RELEASE"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+        "alternativeIds": [],
+        "creationTime": "2017-02-22T07:28:31.465000Z",
+        "credit": [
+          "Takeshi Terada"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n[org.springframework:spring-core](http://search.maven.org/#search%7Cga%7C1%7Ca%3A%22spring-core%22) is a core package within the spring-framework that contains multiple classes and utilities.\n\nAffected versions of this package are vulnerable to Directory Traversal. It allows remote attackers to read arbitrary files via a crafted URL.\n\n## Details\n\nA Directory Traversal attack (also known as path traversal) aims to access files and directories that are stored outside the intended folder. By manipulating files with \"dot-dot-slash (../)\" sequences and its variations, or by using absolute file paths, it may be possible to access arbitrary files and directories stored on file system, including application source code, configuration, and other critical system files.\n\nDirectory Traversal vulnerabilities can be generally divided into two types:\n\n- **Information Disclosure**: Allows the attacker to gain information about the folder structure or read the contents of sensitive files on the system.\n\n`st` is a module for serving static files on web pages, and contains a [vulnerability of this type](https://snyk.io/vuln/npm:st:20140206). In our example, we will serve files from the `public` route.\n\nIf an attacker requests the following URL from our server, it will in turn leak the sensitive private key of the root user.\n\n```\ncurl http://localhost:8080/public/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/root/.ssh/id_rsa\n```\n**Note** `%2e` is the URL encoded version of `.` (dot).\n\n- **Writing arbitrary files**: Allows the attacker to create or replace existing files. This type of vulnerability is also known as `Zip-Slip`. \n\nOne way to achieve this is by using a malicious `zip` archive that holds path traversal filenames. When each filename in the zip archive gets concatenated to the target extraction folder, without validation, the final path ends up outside of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\n\nThe following is an example of a `zip` archive with one benign file and one malicious file. Extracting the malicious file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\n\n```\n2018-04-15 22:04:29 .....           19           19  good.txt\n2018-04-15 22:04:42 .....           20           20  ../../../../../../root/.ssh/authorized_keys\n```\n\n## Remediation\nUpgrade `org.springframework:spring-core` to version 3.2.9.RELEASE, 4.0.5.RELEASE or higher.\n## References\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/e3e71ba92a8b82dadf474eda76cd2741f65a77a8)\n- [GitHub Commit](https://github.com/spring-projects/spring-framework/commit/f6fddeb6eb7da625fd711ab371ff16512f431e8d)\n- [GitHub Issue](https://github.com/spring-projects/spring-framework/issues/16414)\n- [Jira Issue](https://jira.spring.io/browse/SPR-12354)\n- [JVNDB](http://jvndb.jvn.jp/en/contents/2014/JVNDB-2014-000054.html)\n- [NVD](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3578)\n- [Pivotal Security](https://pivotal.io/security/cve-2014-3578)\n- [Pivotal Security](http://www.pivotal.io/security/cve-2014-3578)\n- [RedHat Bugzilla Bug](https://bugzilla.redhat.com/show_bug.cgi?id=1131882)\n",
+        "disclosureTime": "2014-09-05T17:16:58Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "3.2.9.RELEASE",
+          "4.0.5.RELEASE"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JAVA-ORGSPRINGFRAMEWORK-31325",
+        "identifiers": {
+          "CVE": [
+            "CVE-2014-3578"
+          ],
+          "CWE": [
+            "CWE-22"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "spring-core",
+          "groupId": "org.springframework"
+        },
+        "modificationTime": "2020-06-12T14:37:03.069547Z",
+        "moduleName": "org.springframework:spring-core",
+        "packageManager": "maven",
+        "packageName": "org.springframework:spring-core",
+        "patches": [],
+        "proprietary": false,
+        "publicationTime": "2014-09-05T17:16:58Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/e3e71ba92a8b82dadf474eda76cd2741f65a77a8"
+          },
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/spring-projects/spring-framework/commit/f6fddeb6eb7da625fd711ab371ff16512f431e8d"
+          },
+          {
+            "title": "GitHub Issue",
+            "url": "https://github.com/spring-projects/spring-framework/issues/16414"
+          },
+          {
+            "title": "Jira Issue",
+            "url": "https://jira.spring.io/browse/SPR-12354"
+          },
+          {
+            "title": "JVNDB",
+            "url": "http://jvndb.jvn.jp/en/contents/2014/JVNDB-2014-000054.html"
+          },
+          {
+            "title": "NVD",
+            "url": "https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-3578"
+          },
+          {
+            "title": "Pivotal Security",
+            "url": "https://pivotal.io/security/cve-2014-3578"
+          },
+          {
+            "title": "Pivotal Security",
+            "url": "http://www.pivotal.io/security/cve-2014-3578"
+          },
+          {
+            "title": "RedHat Bugzilla Bug",
+            "url": "https://bugzilla.redhat.com/show_bug.cgi?id=1131882"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[3.0.0.RELEASE, 3.2.9.RELEASE)",
+            "[4.0.0.RELEASE, 4.0.5.RELEASE)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Directory Traversal",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.springframework:spring-web@3.2.6.RELEASE",
+          "org.springframework:spring-core@3.2.6.RELEASE"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.springframework:spring-core",
+        "version": "3.2.6.RELEASE"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:H/A:N",
+        "alternativeIds": [],
+        "creationTime": "2018-05-30T12:32:02.349000Z",
+        "credit": [
+          "Snyk Security research Team"
+        ],
+        "cvssScore": 5.5,
+        "description": "## Overview\r\n[`org.zeroturnaround:zt-zip`](https://github.com/zeroturnaround/zt-zip) is a library that helps to create, modify or extract ZIP archives.\r\n\r\nAffected versions of the package are vulnerable to Arbitrary File Write via Archive Extraction (AKA \"Zip Slip\").\r\n\r\nIt is exploited using a specially crafted zip archive, that holds path traversal filenames. When exploited, a filename in a malicious archive is concatenated to the target extraction directory, which results in the final path ending up outside of the target folder. For instance, a zip may hold a file with a \"../../file.exe\" location and thus break out of the target folder. If an executable or a configuration file is overwritten with a file containing malicious code, the problem can turn into an arbitrary code execution issue quite easily.\r\n\r\nThe following is an example of a zip archive with one benign file and one malicious file. Extracting the malicous file will result in traversing out of the target folder, ending up in `/root/.ssh/` overwriting the `authorized_keys` file:\r\n\r\n```\r\n\r\n+2018-04-15 22:04:29 ..... 19 19 good.txt\r\n\r\n+2018-04-15 22:04:42 ..... 20 20 ../../../../../../root/.ssh/authorized_keys\r\n\r\n```\r\n\r\n## Vulnerable Method\r\nThis vulnerability appears in method `process` under class name `Unpacker` in `org/zeroturnaround/zip/ZipUtil.java` [[1]](https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff)\r\n\r\n\r\n## Remediation\r\nUpgrade `org.zeroturnaround:zt-zip` to version 1.13 or higher.\n\n## References\n- [GitHub Commit](https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff)\n- [Zip Slip Advisory](https://github.com/snyk/zip-slip-vulnerability)\n- [Zip Slip Advisory](https://snyk.io/research/zip-slip-vulnerability)\n",
+        "disclosureTime": "2018-04-17T21:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "1.13"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": "ZipUtil$Unpacker",
+              "filePath": "org/zeroturnaround/zip/ZipUtil$Unpacker.java",
+              "functionName": "process"
+            },
+            "version": [
+              "[,1.13)"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "className": "org.zeroturnaround.zip.ZipUtil$Unpacker",
+              "functionName": "process"
+            },
+            "version": [
+              "[,1.13)"
+            ]
+          }
+        ],
+        "id": "SNYK-JAVA-ORGZEROTURNAROUND-31681",
+        "identifiers": {
+          "CVE": [
+            "CVE-2018-1002201"
+          ],
+          "CWE": [
+            "CWE-29"
+          ]
+        },
+        "language": "java",
+        "mavenModuleName": {
+          "artifactId": "zt-zip",
+          "groupId": "org.zeroturnaround"
+        },
+        "modificationTime": "2020-06-09T09:57:45.874102Z",
+        "moduleName": "org.zeroturnaround:zt-zip",
+        "packageManager": "maven",
+        "packageName": "org.zeroturnaround:zt-zip",
+        "patches": [],
+        "proprietary": true,
+        "publicationTime": "2018-05-31T07:32:02Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/zeroturnaround/zt-zip/commit/759b72f33bc8f4d69f84f09fcb7f010ad45d6fff"
+          },
+          {
+            "title": "Zip Slip Advisory",
+            "url": "https://github.com/snyk/zip-slip-vulnerability"
+          },
+          {
+            "title": "Zip Slip Advisory",
+            "url": "https://snyk.io/research/zip-slip-vulnerability"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "[,1.13)"
+          ]
+        },
+        "severity": "medium",
+        "severityWithCritical": "medium",
+        "title": "Arbitrary File Write via Archive Extraction (Zip Slip)",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "org.zeroturnaround:zt-zip@1.12"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.zeroturnaround:zt-zip",
+        "version": "1.12"
+      },
+      {
+        "license": "EPL-1.0",
+        "semver": {
+          "vulnerable": [
+            "[0,)"
+          ]
+        },
+        "id": "snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0",
+        "type": "license",
+        "packageManager": "maven",
+        "language": "java",
+        "packageName": "org.aspectj:aspectjweaver",
+        "title": "EPL-1.0 license",
+        "description": "EPL-1.0 license",
+        "publicationTime": "2021-01-24T06:09:00.675Z",
+        "creationTime": "2021-01-24T06:09:00.675Z",
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/EPL-1.0.txt",
+        "severity": "medium",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.aspectj:aspectjweaver@1.8.2"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.aspectj:aspectjweaver",
+        "version": "1.8.2"
+      },
+      {
+        "license": "LGPL-2.1",
+        "semver": {
+          "vulnerable": [
+            "[0,)"
+          ]
+        },
+        "id": "snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1",
+        "type": "license",
+        "packageManager": "maven",
+        "language": "java",
+        "packageName": "org.hibernate.common:hibernate-commons-annotations",
+        "title": "LGPL-2.1 license",
+        "description": "LGPL-2.1 license",
+        "publicationTime": "2021-01-23T13:15:50.440Z",
+        "creationTime": "2021-01-23T13:15:50.440Z",
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.1.txt",
+        "severity": "medium",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-core@4.3.7.Final",
+          "org.hibernate.common:hibernate-commons-annotations@4.0.5.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate.common:hibernate-commons-annotations",
+        "version": "4.0.5.Final"
+      },
+      {
+        "license": "EPL-1.0",
+        "semver": {
+          "vulnerable": [
+            "[0,)"
+          ]
+        },
+        "id": "snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0",
+        "type": "license",
+        "packageManager": "maven",
+        "language": "java",
+        "packageName": "org.hibernate.javax.persistence:hibernate-jpa-2.1-api",
+        "title": "EPL-1.0 license",
+        "description": "EPL-1.0 license",
+        "publicationTime": "2021-01-23T15:03:54.053Z",
+        "creationTime": "2021-01-23T15:03:54.053Z",
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/EPL-1.0.txt",
+        "severity": "medium",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-core@4.3.7.Final",
+          "org.hibernate.javax.persistence:hibernate-jpa-2.1-api@1.0.0.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate.javax.persistence:hibernate-jpa-2.1-api",
+        "version": "1.0.0.Final"
+      },
+      {
+        "license": "LGPL-2.0",
+        "semver": {
+          "vulnerable": [
+            "[3.5.0.Beta-1, 5.3.1.Final)"
+          ]
+        },
+        "id": "snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0",
+        "type": "license",
+        "packageManager": "maven",
+        "language": "java",
+        "packageName": "org.hibernate:hibernate-entitymanager",
+        "title": "LGPL-2.0 license",
+        "description": "LGPL-2.0 license",
+        "publicationTime": "2021-01-23T14:41:41.088Z",
+        "creationTime": "2021-01-23T14:41:41.088Z",
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.0.txt",
+        "severity": "medium",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-core@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-entitymanager@4.3.7.Final"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.hibernate:hibernate-entitymanager",
+        "version": "4.3.7.Final"
+      },
+      {
+        "license": "LGPL-2.1",
+        "semver": {
+          "vulnerable": [
+            "[3.0.1.GA, 3.1.2.GA)"
+          ]
+        },
+        "id": "snyk:lic:maven:org.jboss.logging:jboss-logging:LGPL-2.1",
+        "type": "license",
+        "packageManager": "maven",
+        "language": "java",
+        "packageName": "org.jboss.logging:jboss-logging",
+        "title": "LGPL-2.1 license",
+        "description": "LGPL-2.1 license",
+        "publicationTime": "2021-01-23T20:25:24.879Z",
+        "creationTime": "2021-01-23T20:25:24.879Z",
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/LGPL-2.1.txt",
+        "severity": "medium",
+        "from": [
+          "io.github.snyk:todolist-mvc@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-struts@1.0-SNAPSHOT",
+          "io.github.snyk:todolist-web-common@1.0-SNAPSHOT",
+          "org.hibernate:hibernate-validator@4.3.1.Final",
+          "org.jboss.logging:jboss-logging@3.1.0.CR2"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "org.jboss.logging:jboss-logging",
+        "version": "3.1.0.CR2"
+      }
+    ],
+    "upgrade": {},
+    "patch": {},
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": false,
+  "filtered": {
+    "ignore": [],
+    "patch": []
+  },
+  "uniqueCount": 58,
+  "projectName": "io.github.snyk:todolist-mvc",
+  "foundProjectCount": 3,
+  "displayTargetFile": "pom.xml",
+  "path": "/home/antoine/Documents/SnykSB/java-goof"
+}

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -50,6 +50,10 @@ beforeEach(() => {
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/test-gomod.json',
           );
+        case '/api/v1/org/playground/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/java-goof.json',
+          );
         case '/api/v1/org/playground/projects':
           return fs.readFileSync(
             fixturesFolderPath +
@@ -125,6 +129,48 @@ describe('Test End 2 End - Inline mode', () => {
       stdinMock.send(
         fs
           .readFileSync(fixturesFolderPath + 'snykTestsOutputs/test-gomod.json')
+          .toString(),
+      );
+      stdinMock.send(null);
+    }, 100);
+
+    const result = await getDelta();
+    expect(consoleOutput).toContain('No new issues found !');
+
+    //expect(mockExit).toHaveBeenCalledWith(0);
+    // => When testing, loaded as module therefore returning code === process.exitCode
+    expect(result).toEqual(0);
+  });
+
+  it('Test Inline mode - no new issue following version upgrade without vuln fix - npm', async () => {
+    setTimeout(() => {
+      stdinMock.send(
+        fs
+          .readFileSync(
+            fixturesFolderPath +
+              'snykTestsOutputs/test-goof-without-more-vuln-following-upgrade.json',
+          )
+          .toString(),
+      );
+      stdinMock.send(null);
+    }, 100);
+
+    const result = await getDelta();
+    expect(consoleOutput).toContain('No new issues found !');
+
+    //expect(mockExit).toHaveBeenCalledWith(0);
+    // => When testing, loaded as module therefore returning code === process.exitCode
+    expect(result).toEqual(0);
+  });
+
+  it('Test Inline mode - no new issue following version upgrade without vuln fix - java', async () => {
+    setTimeout(() => {
+      stdinMock.send(
+        fs
+          .readFileSync(
+            fixturesFolderPath +
+              'snykTestsOutputs/test-java-goof-without-more-vuln-following-upgrade.json',
+          )
           .toString(),
       );
       stdinMock.send(null);


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes https://github.com/snyk-tech-services/snyk-delta/issues/51
Adding check to determine if new issue to exclude the cases where a vulnerable path existed before but changed slightly folowing an upgrade of one or more dependencies in it. 

Determining if a vulnerable path is not new if it matches any of the following conditions:
- vuln.id is identical between monitored snapshot and test snapshot
AND
(
- vuln paths are identical between monitored snapshot and test snapshot
OR
- every dependency of a path remain in the same order irrespective of their versions that may change
)

If an upgrade is performed but a vuln remains on that path still, the versions will change but the path should remain similar, simply with higher versions. If the top level dependency bumps the child dependencies, it should remain similar. if the child dependencies change name, then the vuln path is different and unlikely to be vulnerable.
If pinning bumps a version mid way, it will be fine as well.

Only expect issue is a path changes from Av1 -> Bb1 -> Cv1 to Av1.1 -> Xv1 -> Cv1.1 and Cv1.1 still carries the same vuln as Cv1. This situation should remain very rare.