### PR TITLE
feat: add result passthru behavior for unmonitored projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,20 @@ const result = await getDelta(jsonResultsFromSnykTest);
 ```
 Result is a number:
 - 0 for no new issue
-- 1 for new issue(s)
-- 2 for errors like invalid auth or not found monitored project to compare against
+- 1 for new issue(s) or when using strictMode and the unmonitored project has issues (see more details below in StrictMode)
+- 2 for errors like invalid auth
 
 Actual issue(s) details will be listed on stdout.\
 JSON output will be added soon.
+
+## Help
+-h to list help
+
+### StrictMode
+When snyk-delta compares test results, it tries to find the same project, monitored on the Snyk platform.
+If no monitored project is found, is will return all the issues found by the CLI scan, essentially acting as pass through.
+
+The return code will be 0 if no issue, 1 if issues.
 
 ### Caution
 Usage as a module requires list of issues coming from Snyk CLI.

--- a/src/lib/snyk/issues.ts
+++ b/src/lib/snyk/issues.ts
@@ -152,6 +152,7 @@ const displayNewLicenseIssues = (newLicenseIssues: Array<any>, mode: string): vo
       })
 }
 
+
 const getIssuesDetailsPerPackage = (issuesArray: Array<any>, packageName: string, packageVersion?: string): Array<any> => {
   if(!packageVersion){
     return []

--- a/src/lib/snyk/snyk.ts
+++ b/src/lib/snyk/snyk.ts
@@ -22,10 +22,7 @@ const getProjectUUID = async (
       project.name == nonUUIDProjectID && project.origin == projectType,
   );
   if (selectedProjectArray.length == 0) {
-    throw new Error.NotFoundError(
-      'Snyk API - Could not find a monitored project matching. \
-                                        Make sure to specify the right org when snyk test using --org',
-    );
+    return ''
   } else if (selectedProjectArray.length > 1) {
     throw new Error.NotFoundError(
       'Snyk API - Could not find a monitored project matching accurately. \

--- a/test/fixtures/snykTestsOutputs/test-unmonitored-goof.json
+++ b/test/fixtures/snykTestsOutputs/test-unmonitored-goof.json
@@ -1,0 +1,936 @@
+{
+  "vulnerabilities": [
+    {
+      "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+      "alternativeIds": [],
+      "creationTime": "2020-03-07T00:18:41.509507Z",
+      "credit": [
+        "Peter van der Zee"
+      ],
+      "cvssScore": 7.5,
+      "description": "## Overview\n\n[acorn](https://github.com/acornjs/acorn) is a tiny, fast JavaScript parser written in JavaScript.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nvia a regex in the form of `/[x-\\ud800]/u`, which causes the parser to enter an infinite loop. \r\n\r\nThis string is not a valid `UTF16` and is therefore not sanitized before reaching the parser. An application which processes untrusted input and passes it directly to `acorn`, will allow attackers to leverage the vulnerability leading to a Denial of Service.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `acorn` to version 5.7.4, 6.4.1, 7.1.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802)\n\n- [GitHub Issue 6.x Branch](https://github.com/acornjs/acorn/issues/929)\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1488)\n",
+      "disclosureTime": "2020-03-02T19:21:25Z",
+      "exploit": "Not Defined",
+      "fixedIn": [
+        "5.7.4",
+        "6.4.1",
+        "7.1.1"
+      ],
+      "functions": [],
+      "functions_new": [],
+      "id": "SNYK-JS-ACORN-559469",
+      "identifiers": {
+        "CVE": [],
+        "CWE": [
+          "CWE-400"
+        ],
+        "GHSA": [
+          "GHSA-6chw-6frg-f759"
+        ],
+        "NSP": [
+          1488
+        ]
+      },
+      "language": "js",
+      "modificationTime": "2020-03-10T10:19:13.616093Z",
+      "moduleName": "acorn",
+      "packageManager": "npm",
+      "packageName": "acorn",
+      "patches": [],
+      "publicationTime": "2020-03-07T00:19:23Z",
+      "references": [
+        {
+          "title": "GitHub Commit",
+          "url": "https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802"
+        },
+        {
+          "title": "GitHub Issue 6.x Branch",
+          "url": "https://github.com/acornjs/acorn/issues/929"
+        },
+        {
+          "title": "NPM Security Advisory",
+          "url": "https://www.npmjs.com/advisories/1488"
+        }
+      ],
+      "semver": {
+        "vulnerable": [
+          ">=5.5.0 <5.7.4",
+          ">=6.0.0 <6.4.1",
+          ">=7.0.0 <7.1.1"
+        ]
+      },
+      "severity": "high",
+      "title": "Regular Expression Denial of Service (ReDoS)",
+      "from": [
+        "goof@0.0.3",
+        "@snyk/nodejs-runtime-agent@1.14.0",
+        "acorn@5.7.3"
+      ],
+      "upgradePath": [
+        false,
+        "@snyk/nodejs-runtime-agent@1.14.0",
+        "acorn@5.7.4"
+      ],
+      "isUpgradable": true,
+      "isPatchable": false,
+      "name": "acorn",
+      "version": "5.7.3"
+    },
+    {
+      "license": "GPL-2.0",
+      "semver": {
+        "vulnerable": [
+          ">=0"
+        ]
+      },
+      "id": "snyk:lic:npm:goof:GPL-2.0",
+      "type": "license",
+      "packageManager": "npm",
+      "language": "js",
+      "packageName": "goof",
+      "title": "GPL-2.0 license",
+      "description": "GPL-2.0 license",
+      "publicationTime": "2020-04-09T19:48:50.751Z",
+      "creationTime": "2020-04-09T19:48:50.751Z",
+      "patches": [],
+      "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/GPL-2.0.txt",
+      "severity": "medium",
+      "from": [
+        "goof@0.0.3"
+      ],
+      "upgradePath": [],
+      "isUpgradable": false,
+      "isPatchable": false,
+      "name": "goof",
+      "version": "0.0.3"
+    }
+  ],
+  "ok": false,
+  "dependencyCount": 418,
+  "org": "playground",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.14.1\n# ignores vulnerabilities until expiry date; change duration by modifying expiry date\nignore:\n  'npm:ejs:20161128':\n    - ejs-locals > ejs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:ejs:20161130':\n    - ejs-locals > ejs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:ejs:20161130-1':\n    - ejs-locals > ejs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:hoek:20180212':\n    - tap > codecov.io > request > hawk > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n    - tap > codecov.io > request > hawk > boom > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n    - tap > codecov.io > request > hawk > sntp > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n    - tap > codecov.io > request > hawk > cryptiles > boom > hoek:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'npm:qs:20170213':\n    - tap > codecov.io > request > qs:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'snyk:lic:npm:goof:GPL-2.0':\n    - '':\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n  'snyk:lic:npm:symbol:MPL-2.0':\n    - tap > nyc > yargs > pkg-conf > symbol:\n        reason: None given\n        expires: '2019-10-23T11:31:59.805Z'\n        source: cli\n# patches apply the minimum changes required to fix a vulnerability\npatch:\n  'npm:negotiator:20160616':\n    - errorhandler > accepts > negotiator:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:ms:20151024':\n    - humanize-ms > ms:\n        patched: '2019-09-23T21:21:17.183Z'\n  'npm:hawk:20160119':\n    - tap > codecov.io > request > hawk:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:http-signature:20150122':\n    - tap > codecov.io > request > http-signature:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:mime:20170907':\n    - tap > codecov.io > request > form-data > mime:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:request:20160119':\n    - tap > codecov.io > request:\n        patched: '2019-09-23T11:31:09.532Z'\n  'npm:tunnel-agent:20170305':\n    - tap > codecov.io > request > tunnel-agent:\n        patched: '2019-09-23T11:31:09.532Z'\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+    "severities": {
+      "AGPL-1.0": "high",
+      "AGPL-3.0": "high",
+      "CDDL-1.0": "medium",
+      "CPOL-1.02": "high",
+      "GPL-2.0": "medium",
+      "LGPL-2.0": "low",
+      "LGPL-2.1": "low",
+      "LGPL-2.1+": "medium",
+      "LGPL-3.0": "low",
+      "LGPL-3.0+": "medium",
+      "MPL-1.1": "medium",
+      "MPL-2.0": "medium",
+      "MS-RL": "medium",
+      "SimPL-2.0": "high"
+    },
+    "orgLicenseRules": {
+      "AGPL-1.0": {
+        "licenseType": "AGPL-1.0",
+        "severity": "high",
+        "instructions": "jbvhgvg Test"
+      },
+      "AGPL-3.0": {
+        "licenseType": "AGPL-3.0",
+        "severity": "high",
+        "instructions": ""
+      },
+      "CDDL-1.0": {
+        "licenseType": "CDDL-1.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "CPOL-1.02": {
+        "licenseType": "CPOL-1.02",
+        "severity": "high",
+        "instructions": ""
+      },
+      "GPL-2.0": {
+        "licenseType": "GPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-2.0": {
+        "licenseType": "LGPL-2.0",
+        "severity": "low",
+        "instructions": ""
+      },
+      "LGPL-2.1": {
+        "licenseType": "LGPL-2.1",
+        "severity": "low",
+        "instructions": ""
+      },
+      "LGPL-2.1+": {
+        "licenseType": "LGPL-2.1+",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "LGPL-3.0": {
+        "licenseType": "LGPL-3.0",
+        "severity": "low",
+        "instructions": ""
+      },
+      "LGPL-3.0+": {
+        "licenseType": "LGPL-3.0+",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-1.1": {
+        "licenseType": "MPL-1.1",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MPL-2.0": {
+        "licenseType": "MPL-2.0",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "MS-RL": {
+        "licenseType": "MS-RL",
+        "severity": "medium",
+        "instructions": ""
+      },
+      "SimPL-2.0": {
+        "licenseType": "SimPL-2.0",
+        "severity": "high",
+        "instructions": ""
+      }
+    }
+  },
+  "packageManager": "npm",
+  "ignoreSettings": {
+    "adminOnly": false,
+    "reasonRequired": false,
+    "disregardFilesystemIgnores": false
+  },
+  "summary": "15 vulnerable dependency paths",
+  "remediation": {
+    "unresolved": [
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [],
+        "creationTime": "2020-03-07T00:18:41.509507Z",
+        "credit": [
+          "Peter van der Zee"
+        ],
+        "cvssScore": 7.5,
+        "description": "## Overview\n\n[acorn](https://github.com/acornjs/acorn) is a tiny, fast JavaScript parser written in JavaScript.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nvia a regex in the form of `/[x-\\ud800]/u`, which causes the parser to enter an infinite loop. \r\n\r\nThis string is not a valid `UTF16` and is therefore not sanitized before reaching the parser. An application which processes untrusted input and passes it directly to `acorn`, will allow attackers to leverage the vulnerability leading to a Denial of Service.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `acorn` to version 5.7.4, 6.4.1, 7.1.1 or higher.\n\n\n## References\n\n- [GitHub Commit](https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802)\n\n- [GitHub Issue 6.x Branch](https://github.com/acornjs/acorn/issues/929)\n\n- [NPM Security Advisory](https://www.npmjs.com/advisories/1488)\n",
+        "disclosureTime": "2020-03-02T19:21:25Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "5.7.4",
+          "6.4.1",
+          "7.1.1"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-ACORN-559469",
+        "identifiers": {
+          "CVE": [],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-6chw-6frg-f759"
+          ],
+          "NSP": [
+            1488
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2020-03-10T10:19:13.616093Z",
+        "moduleName": "acorn",
+        "packageManager": "npm",
+        "packageName": "acorn",
+        "patches": [],
+        "publicationTime": "2020-03-07T00:19:23Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/acornjs/acorn/commit/793c0e569ed1158672e3a40aeed1d8518832b802"
+          },
+          {
+            "title": "GitHub Issue 6.x Branch",
+            "url": "https://github.com/acornjs/acorn/issues/929"
+          },
+          {
+            "title": "NPM Security Advisory",
+            "url": "https://www.npmjs.com/advisories/1488"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            ">=5.5.0 <5.7.4",
+            ">=6.0.0 <6.4.1",
+            ">=7.0.0 <7.1.1"
+          ]
+        },
+        "severity": "high",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "from": [
+          "goof@0.0.3",
+          "@snyk/nodejs-runtime-agent@1.14.0",
+          "acorn@5.7.3"
+        ],
+        "upgradePath": [
+          false,
+          "@snyk/nodejs-runtime-agent@1.14.0",
+          "acorn@5.7.4"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "acorn",
+        "version": "5.7.3"
+      },
+      {
+        "CVSSv3": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L/E:P/RL:O/RC:C",
+        "alternativeIds": [],
+        "creationTime": "2020-03-11T08:25:47.093051Z",
+        "credit": [
+          "Snyk Security Team"
+        ],
+        "cvssScore": 5.6,
+        "description": "## Overview\n\n[minimist](https://www.npmjs.com/package/minimist) is a parse argument options module.\n\n\nAffected versions of this package are vulnerable to Prototype Pollution.\nThe library could be tricked into adding or modifying properties of `Object.prototype` using a `constructor` or `__proto__` payload.\r\n\r\n## PoC by Snyk\r\n```\r\nrequire('minimist')('--__proto__.injected0 value0'.split(' '));\r\nconsole.log(({}).injected0 === 'value0'); // true\r\n\r\nrequire('minimist')('--constructor.prototype.injected1 value1'.split(' '));\r\nconsole.log(({}).injected1 === 'value1'); // true\r\n```\n\n## Details\nPrototype Pollution is a vulnerability affecting JavaScript. Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects. JavaScript allows all Object attributes to be altered, including their magical attributes such as `_proto_`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values.  Properties on the `Object.prototype` are then inherited by all the JavaScript objects through the prototype chain. When that happens, this leads to either denial of service by triggering JavaScript exceptions, or it tampers with the application source code to force the code path that the attacker injects, thereby leading to remote code execution.\r\n\r\nThere are two main ways in which the pollution of prototypes occurs:\r\n\r\n-   Unsafe `Object` recursive merge\r\n    \r\n-   Property definition by path\r\n    \r\n\r\n### Unsafe Object recursive merge\r\n\r\nThe logic of a vulnerable recursive merge function follows the following high-level model:\r\n```\r\nmerge (target, source)\r\n\r\n  foreach property of source\r\n\r\n    if property exists and is an object on both the target and the source\r\n\r\n      merge(target[property], source[property])\r\n\r\n    else\r\n\r\n      target[property] = source[property]\r\n```\r\n<br>  \r\n\r\nWhen the source object contains a property named `_proto_` defined with `Object.defineProperty()` , the condition that checks if the property exists and is an object on both the target and the source passes and the merge recurses with the target, being the prototype of `Object` and the source of `Object` as defined by the attacker. Properties are then copied on the `Object` prototype.\r\n\r\nClone operations are a special sub-class of unsafe recursive merges, which occur when a recursive merge is conducted on an empty object: `merge({},source)`.\r\n\r\n`lodash` and `Hoek` are examples of libraries susceptible to recursive merge attacks.\r\n\r\n### Property definition by path\r\n\r\nThere are a few JavaScript libraries that use an API to define property values on an object based on a given path. The function that is generally affected contains this signature: `theFunction(object, path, value)`\r\n\r\nIf the attacker can control the value of “path”, they can set this value to `_proto_.myValue`. `myValue` is then assigned to the prototype of the class of the object.\r\n\r\n## Types of attacks\r\n\r\nThere are a few methods by which Prototype Pollution can be manipulated:\r\n\r\n| Type |Origin  |Short description |\r\n|--|--|--|\r\n| **Denial of service (DoS)**|Client  |This is the most likely attack. <br>DoS occurs when `Object` holds generic functions that are implicitly called for various operations (for example, `toString` and `valueOf`). <br> The attacker pollutes `Object.prototype.someattr` and alters its state to an unexpected value such as `Int` or `Object`. In this case, the code fails and is likely to cause a denial of service.  <br>**For example:** if an attacker pollutes `Object.prototype.toString` by defining it as an integer, if the codebase at any point was reliant on `someobject.toString()` it would fail. |\r\n |**Remote Code Execution**|Client|Remote code execution is generally only possible in cases where the codebase evaluates a specific attribute of an object, and then executes that evaluation.<br>**For example:** `eval(someobject.someattr)`. In this case, if the attacker pollutes `Object.prototype.someattr` they are likely to be able to leverage this in order to execute code.|\r\n|**Property Injection**|Client|The attacker pollutes properties that the codebase relies on for their informative value, including security properties such as cookies or tokens.<br>  **For example:** if a codebase checks privileges for `someuser.isAdmin`, then when the attacker pollutes `Object.prototype.isAdmin` and sets it to equal `true`, they can then achieve admin privileges.|\r\n\r\n## Affected environments\r\n\r\nThe following environments are susceptible to a Prototype Pollution attack:\r\n\r\n-   Application server\r\n    \r\n-   Web server\r\n    \r\n\r\n## How to prevent\r\n\r\n1.  Freeze the prototype— use `Object.freeze (Object.prototype)`.\r\n    \r\n2.  Require schema validation of JSON input.\r\n    \r\n3.  Avoid using unsafe recursive merge functions.\r\n    \r\n4.  Consider using objects without prototypes (for example, `Object.create(null)`), breaking the prototype chain and preventing pollution.\r\n    \r\n5.  As a best practice use `Map` instead of `Object`.\r\n\r\n### For more information on this vulnerability type:\r\n\r\n[Arteau, Oliver. “JavaScript prototype pollution attack in NodeJS application.” GitHub, 26 May 2018](https://github.com/HoLyVieR/prototype-pollution-nsec18/blob/master/paper/JavaScript_prototype_pollution_attack_in_NodeJS.pdf)\n\n## Remediation\n\nUpgrade `minimist` to version 0.2.1, 1.2.3 or higher.\n\n\n## References\n\n- [Command Injection PoC](https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a)\n\n- [GitHub Fix Commit #1](https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94)\n\n- [GitHub Fix Commit #2](https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab)\n\n- [Snyk Research Blog](https://snyk.io/blog/prototype-pollution-minimist/)\n",
+        "disclosureTime": "2020-03-10T08:22:24Z",
+        "exploit": "Proof of Concept",
+        "fixedIn": [
+          "0.2.1",
+          "1.2.3"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "SNYK-JS-MINIMIST-559764",
+        "identifiers": {
+          "CVE": [
+            "CVE-2020-7598"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "GHSA": [
+            "GHSA-vh95-rmgr-6w4m"
+          ],
+          "NSP": [
+            1179
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2020-03-18T10:21:38.800415Z",
+        "moduleName": "minimist",
+        "packageManager": "npm",
+        "packageName": "minimist",
+        "patches": [],
+        "publicationTime": "2020-03-11T08:22:19Z",
+        "references": [
+          {
+            "title": "Command Injection PoC",
+            "url": "https://gist.github.com/Kirill89/47feb345b09bf081317f08dd43403a8a"
+          },
+          {
+            "title": "GitHub Fix Commit #1",
+            "url": "https://github.com/substack/minimist/commit/63e7ed05aa4b1889ec2f3b196426db4500cbda94"
+          },
+          {
+            "title": "GitHub Fix Commit #2",
+            "url": "https://github.com/substack/minimist/commit/38a4d1caead72ef99e824bb420a2528eec03d9ab"
+          },
+          {
+            "title": "Snyk Research Blog",
+            "url": "https://snyk.io/blog/prototype-pollution-minimist/"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.2.1",
+            ">=1.0.0 <1.2.3"
+          ]
+        },
+        "severity": "medium",
+        "title": "Prototype Pollution",
+        "from": [
+          "goof@0.0.3",
+          "snyk@1.228.3",
+          "update-notifier@2.5.0",
+          "latest-version@3.1.0",
+          "package-json@4.0.1",
+          "registry-url@3.1.0",
+          "rc@1.2.8",
+          "minimist@1.2.0"
+        ],
+        "upgradePath": [
+          false,
+          "snyk@1.228.3",
+          "update-notifier@2.5.0",
+          "latest-version@3.1.0",
+          "package-json@4.0.1",
+          "registry-url@3.1.0",
+          "rc@1.2.8",
+          "minimist@1.2.3"
+        ],
+        "isUpgradable": true,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "minimist",
+        "version": "1.2.0"
+      },
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        "alternativeIds": [
+          "SNYK-JS-EJS-10218"
+        ],
+        "creationTime": "2016-11-28T18:44:12.405000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 8.1,
+        "description": "## Overview\r\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\r\nAffected versions of the package are vulnerable to _Remote Code Execution_ by letting the attacker under certain conditions control the source folder from which the engine renders include files.\r\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\r\n\r\nThere's also a [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour. \r\n\r\n## Details\r\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\r\n\r\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\r\n```js\r\nejs.render(str, data, options);\r\n\r\nejs.renderFile(filename, data, options, callback)\r\n```\r\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\r\n```js\r\nejs.render(str, dataAndOptions);\r\n\r\nejs.renderFile(filename, dataAndOptions, callback)\r\n```\r\n\r\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `root` option, which allows changing the project root for includes with an absolute path.  \r\n\r\n```js\r\nejs.renderFile('my-template', {root:'/bad/root/'}, callback);\r\n```\r\n\r\nBy passing along the root directive in the line above, any includes would now be pulled from `/bad/root` instead of the path intended. This allows the attacker to take control of the root directory for included scripts and divert it to a library under his control, thus leading to remote code execution.\r\n\r\nThe [fix](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\r\n\r\n## Disclosure Timeline\r\n- November 27th, 2016 - Reported the issue to package owner.\r\n- November 27th, 2016 - Issue acknowledged by package owner.\r\n- November 28th, 2016 - Issue fixed and version `2.5.3` released.\r\n\r\n## Remediation\r\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\r\nOtherwise, Upgrade `ejs` to version `2.5.3` or higher.\r\n\r\n## References\r\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\r\n- [Fix commit](https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6)",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.5.3"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "ejs.js",
+              "functionName": "1.exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "lib/ejs.js",
+              "functionName": "exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "ejs.js",
+              "functionName": "1.cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "lib/ejs.js",
+              "functionName": "cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "ejs.js",
+              "functionName": "1.exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/ejs.js",
+              "functionName": "exports.render"
+            },
+            "version": [
+              "<2.2.1"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "ejs.js",
+              "functionName": "1.cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "lib/ejs.js",
+              "functionName": "cpOptsInData"
+            },
+            "version": [
+              ">=2.2.1 <2.5.3"
+            ]
+          }
+        ],
+        "id": "npm:ejs:20161128",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EJS-10218"
+          ],
+          "CVE": [
+            "CVE-2017-1000228"
+          ],
+          "CWE": [
+            "CWE-94"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-03-05T14:14:20.921506Z",
+        "moduleName": "ejs",
+        "packageManager": "npm",
+        "packageName": "ejs",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:ejs:20161128:0",
+            "modificationTime": "2019-12-03T11:40:45.851976Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ejs/20161128/ejs_20161128_0_0_3d447c5a335844b25faec04b1132dbc721f9c8f6.patch"
+            ],
+            "version": "<2.5.3 >=2.2.4"
+          }
+        ],
+        "publicationTime": "2016-11-28T18:44:12Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mde/ejs/commit/3d447c5a335844b25faec04b1132dbc721f9c8f6"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.5.3"
+          ]
+        },
+        "severity": "high",
+        "title": "Arbitrary Code Execution",
+        "from": [
+          "goof@0.0.3",
+          "ejs-locals@1.0.2",
+          "ejs@0.8.8"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "ejs",
+        "version": "0.8.8"
+      },
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:N/A:N",
+        "alternativeIds": [
+          "SNYK-JS-EJS-10225"
+        ],
+        "creationTime": "2016-11-28T18:44:12.405000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Cross-site Scripting_ by letting the attacker under certain conditions control and override the `filename` option causing it to render the value as is, without escaping it.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Denial of Service](https://snyk.io/vuln/npm:ejs:20161130-1) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `filename` option, which will be rendered as is when an error occurs during rendering. \n\n```js\nejs.renderFile('my-template', {filename:'<script>alert(1)</script>'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.5.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:ejs:20161130",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EJS-10225"
+          ],
+          "CVE": [
+            "CVE-2017-1000188"
+          ],
+          "CWE": [
+            "CWE-79"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-02-18T08:31:22.194966Z",
+        "moduleName": "ejs",
+        "packageManager": "npm",
+        "packageName": "ejs",
+        "patches": [],
+        "publicationTime": "2016-12-06T15:00:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.5.5"
+          ]
+        },
+        "severity": "medium",
+        "title": "Cross-site Scripting (XSS)",
+        "from": [
+          "goof@0.0.3",
+          "ejs-locals@1.0.2",
+          "ejs@0.8.8"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "ejs",
+        "version": "0.8.8"
+      },
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:N/A:H",
+        "alternativeIds": [
+          "SNYK-JS-EJS-10226"
+        ],
+        "creationTime": "2016-11-28T18:44:12.405000Z",
+        "credit": [
+          "Snyk Security Research Team"
+        ],
+        "cvssScore": 5.9,
+        "description": "## Overview\n[`ejs`](https://www.npmjs.com/package/ejs) is a popular JavaScript templating engine.\nAffected versions of the package are vulnerable to _Denial of Service_ by letting the attacker under certain conditions control and override the `localNames` option causing it to crash.\nYou can read more about this vulnerability on the [Snyk blog](https://snyk.io/blog/fixing-ejs-rce-vuln).\n\nThere's also a [Remote Code Execution](https://snyk.io/vuln/npm:ejs:20161128) & [Cross-site Scripting](https://snyk.io/vuln/npm:ejs:20161130) vulnerabilities caused by the same behaviour.\n\n## Details\n`ejs` provides a few different options for you to render a template, two being very similar: `ejs.render()` and `ejs.renderFile()`. The only difference being that `render` expects a string to be used for the template and `renderFile` expects a path to a template file.\n\nBoth functions can be invoked in two ways. The first is calling them with `template`, `data`, and `options`:\n```js\nejs.render(str, data, options);\n\nejs.renderFile(filename, data, options, callback)\n```\nThe second way would be by calling only the `template` and `data`, while `ejs` lets the `options` be passed as part of the `data`:\n```js\nejs.render(str, dataAndOptions);\n\nejs.renderFile(filename, dataAndOptions, callback)\n```\n\nIf used with a variable list supplied by the user (e.g. by reading it from the URI with `qs` or equivalent), an attacker can control `ejs` options. This includes the `localNames` option, which will cause the renderer to crash.\n\n```js\nejs.renderFile('my-template', {localNames:'try'}, callback);\n```\n\nThe [fix](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f) introduced in version `2.5.3` blacklisted `root` options from options passed via the `data` object.\n\n## Disclosure Timeline\n- November 28th, 2016 - Reported the issue to package owner.\n- November 28th, 2016 - Issue acknowledged by package owner.\n- December 06th, 2016 - Issue fixed and version `2.5.5` released.\n\n## Remediation\nThe vulnerability can be resolved by either using the GitHub integration to [generate a pull-request](https://snyk.io/org/projects) from your dashboard or by running `snyk wizard` from the command-line interface.\nOtherwise, Upgrade `ejs` to version `2.5.5` or higher.\n\n## References\n- [Snyk Blog](https://snyk.io/blog/fixing-ejs-rce-vuln)\n- [Fix commit](https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f)\n",
+        "disclosureTime": "2016-11-27T22:00:00Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "2.5.5"
+        ],
+        "functions": [],
+        "functions_new": [],
+        "id": "npm:ejs:20161130-1",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-EJS-10226"
+          ],
+          "CVE": [
+            "CVE-2017-1000189"
+          ],
+          "CWE": [
+            "CWE-400"
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-02-18T08:31:22.206452Z",
+        "moduleName": "ejs",
+        "packageManager": "npm",
+        "packageName": "ejs",
+        "patches": [],
+        "publicationTime": "2016-12-06T15:00:00Z",
+        "references": [
+          {
+            "title": "GitHub Commit",
+            "url": "https://github.com/mde/ejs/commit/49264e0037e313a0a3e033450b5c184112516d8f"
+          },
+          {
+            "title": "Snyk Blog",
+            "url": "https://snyk.io/blog/fixing-ejs-rce-vuln"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<2.5.5"
+          ]
+        },
+        "severity": "medium",
+        "title": "Denial of Service (DoS)",
+        "from": [
+          "goof@0.0.3",
+          "ejs-locals@1.0.2",
+          "ejs@0.8.8"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "ejs",
+        "version": "0.8.8"
+      },
+      {
+        "license": "GPL-2.0",
+        "semver": {
+          "vulnerable": [
+            ">=0"
+          ]
+        },
+        "id": "snyk:lic:npm:goof:GPL-2.0",
+        "type": "license",
+        "packageManager": "npm",
+        "language": "js",
+        "packageName": "goof",
+        "title": "GPL-2.0 license",
+        "description": "GPL-2.0 license",
+        "publicationTime": "2020-04-09T19:48:50.751Z",
+        "creationTime": "2020-04-09T19:48:50.751Z",
+        "patches": [],
+        "licenseTemplateUrl": "https://raw.githubusercontent.com/spdx/license-list/master/GPL-2.0.txt",
+        "severity": "medium",
+        "from": [
+          "goof@0.0.3"
+        ],
+        "upgradePath": [],
+        "isUpgradable": false,
+        "isPatchable": false,
+        "isPinnable": false,
+        "name": "goof",
+        "version": "0.0.3"
+      }
+    ],
+    "upgrade": {
+      "express-fileupload@0.0.5": {
+        "upgradeTo": "express-fileupload@1.1.6",
+        "upgrades": [
+          "express-fileupload@0.0.5"
+        ],
+        "vulns": [
+          "SNYK-JS-EXPRESSFILEUPLOAD-473997"
+        ]
+      },
+      "snyk@1.228.3": {
+        "upgradeTo": "snyk@1.290.1",
+        "upgrades": [
+          "dot-prop@4.2.0"
+        ],
+        "vulns": [
+          "SNYK-JS-DOTPROP-543489"
+        ]
+      }
+    },
+    "patch": {
+      "SNYK-JS-HTTPSPROXYAGENT-469131": {
+        "paths": [
+          {
+            "snyk > proxy-agent > https-proxy-agent": {
+              "patched": "2020-04-09T21:29:35.234Z"
+            }
+          },
+          {
+            "snyk > proxy-agent > pac-proxy-agent > https-proxy-agent": {
+              "patched": "2020-04-09T21:29:35.234Z"
+            }
+          }
+        ]
+      },
+      "SNYK-JS-TREEKILL-536781": {
+        "paths": [
+          {
+            "snyk > snyk-sbt-plugin > tree-kill": {
+              "patched": "2020-04-09T21:29:35.234Z"
+            }
+          }
+        ]
+      }
+    },
+    "ignore": {},
+    "pin": {}
+  },
+  "filesystemPolicy": true,
+  "filtered": {
+    "ignore": [],
+    "patch": [
+      {
+        "CVSSv3": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:L",
+        "alternativeIds": [
+          "SNYK-JS-MS-10064"
+        ],
+        "creationTime": "2015-11-06T02:09:36.187000Z",
+        "credit": [
+          "Adam Baldwin"
+        ],
+        "cvssScore": 5.3,
+        "description": "## Overview\n\n[ms](https://www.npmjs.com/package/ms) is a tiny milisecond conversion utility.\n\n\nAffected versions of this package are vulnerable to Regular Expression Denial of Service (ReDoS)\nattack when converting a time period string (i.e. `\"2 days\"`, `\"1h\"`) into a milliseconds integer. A malicious user could pass extremely long strings to `ms()`, causing the server to take a long time to process, subsequently blocking the event loop for that extended period.\n\n## Details\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its original and legitimate users. There are many types of DoS attacks, ranging from trying to clog the network pipes to the system by generating a large volume of traffic from many machines (a Distributed Denial of Service - DDoS - attack) to sending crafted requests that cause a system to crash or take a disproportional amount of time to process.\r\n\r\nThe Regular expression Denial of Service (ReDoS) is a type of Denial of Service attack. Regular expressions are incredibly powerful, but they aren't very intuitive and can ultimately end up making it easy for attackers to take your site down.\r\n\r\nLet’s take the following regular expression as an example:\r\n```js\r\nregex = /A(B|C+)+D/\r\n```\r\n\r\nThis regular expression accomplishes the following:\r\n- `A` The string must start with the letter 'A'\r\n- `(B|C+)+` The string must then follow the letter A with either the letter 'B' or some number of occurrences of the letter 'C' (the `+` matches one or more times). The `+` at the end of this section states that we can look for one or more matches of this section.\r\n- `D` Finally, we ensure this section of the string ends with a 'D'\r\n\r\nThe expression would match inputs such as `ABBD`, `ABCCCCD`, `ABCBCCCD` and `ACCCCCD`\r\n\r\nIt most cases, it doesn't take very long for a regex engine to find a match:\r\n\r\n```bash\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCD\")'\r\n0.04s user 0.01s system 95% cpu 0.052 total\r\n\r\n$ time node -e '/A(B|C+)+D/.test(\"ACCCCCCCCCCCCCCCCCCCCCCCCCCCCX\")'\r\n1.79s user 0.02s system 99% cpu 1.812 total\r\n```\r\n\r\nThe entire process of testing it against a 30 characters long string takes around ~52ms. But when given an invalid string, it takes nearly two seconds to complete the test, over ten times as long as it took to test a valid string. The dramatic difference is due to the way regular expressions get evaluated.\r\n\r\nMost Regex engines will work very similarly (with minor differences). The engine will match the first possible way to accept the current character and proceed to the next one. If it then fails to match the next one, it will backtrack and see if there was another way to digest the previous character. If it goes too far down the rabbit hole only to find out the string doesn’t match in the end, and if many characters have multiple valid regex paths, the number of backtracking steps can become very large, resulting in what is known as _catastrophic backtracking_.\r\n\r\nLet's look at how our expression runs into this problem, using a shorter string: \"ACCCX\". While it seems fairly straightforward, there are still four different ways that the engine could match those three C's:\r\n1. CCC\r\n2. CC+C\r\n3. C+CC\r\n4. C+C+C.\r\n\r\nThe engine has to try each of those combinations to see if any of them potentially match against the expression. When you combine that with the other steps the engine must take, we can use [RegEx 101 debugger](https://regex101.com/debugger) to see the engine has to take a total of 38 steps before it can determine the string doesn't match.\r\n\r\nFrom there, the number of steps the engine must use to validate a string just continues to grow.\r\n\r\n| String | Number of C's | Number of steps |\r\n| -------|-------------:| -----:|\r\n| ACCCX | 3 | 38\r\n| ACCCCX | 4 | 71\r\n| ACCCCCX | 5 | 136\r\n| ACCCCCCCCCCCCCCX | 14 | 65,553\r\n\r\n\r\nBy the time the string includes 14 C's, the engine has to take over 65,000 steps just to see if the string is valid. These extreme situations can cause them to work very slowly (exponentially related to input size, as shown above), allowing an attacker to exploit this and can cause the service to excessively consume CPU, resulting in a Denial of Service.\n\n## Remediation\n\nUpgrade `ms` to version 0.7.1 or higher.\n\n\n## References\n\n- [OSS security Advisory](https://www.openwall.com/lists/oss-security/2016/04/20/11)\n\n- [OWASP - ReDoS](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS)\n\n- [Security Focus](https://www.securityfocus.com/bid/96389)\n",
+        "disclosureTime": "2015-10-24T20:39:59Z",
+        "exploit": "Not Defined",
+        "fixedIn": [
+          "0.7.1"
+        ],
+        "functions": [
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "ms.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.1.0 <=0.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "className": null,
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.3.0 <0.7.1"
+            ]
+          }
+        ],
+        "functions_new": [
+          {
+            "functionId": {
+              "filePath": "ms.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.1.0 <=0.3.0"
+            ]
+          },
+          {
+            "functionId": {
+              "filePath": "index.js",
+              "functionName": "parse"
+            },
+            "version": [
+              ">0.3.0 <0.7.1"
+            ]
+          }
+        ],
+        "id": "npm:ms:20151024",
+        "identifiers": {
+          "ALTERNATIVE": [
+            "SNYK-JS-MS-10064"
+          ],
+          "CVE": [
+            "CVE-2015-8315"
+          ],
+          "CWE": [
+            "CWE-400"
+          ],
+          "NSP": [
+            46
+          ]
+        },
+        "language": "js",
+        "modificationTime": "2019-05-23T07:46:17.408630Z",
+        "moduleName": "ms",
+        "packageManager": "npm",
+        "packageName": "ms",
+        "patches": [
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:0",
+            "modificationTime": "2019-12-03T11:40:45.772009Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_0_0_48701f029417faf65e6f5e0b61a3cebe5436b07b.patch"
+            ],
+            "version": "=0.7.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:1",
+            "modificationTime": "2019-12-03T11:40:45.773094Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_1_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk.patch"
+            ],
+            "version": "<0.7.0 >=0.6.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:2",
+            "modificationTime": "2019-12-03T11:40:45.774221Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_2_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk2.patch"
+            ],
+            "version": "<0.6.0 >0.3.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:3",
+            "modificationTime": "2019-12-03T11:40:45.775292Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_3_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk3.patch"
+            ],
+            "version": "=0.3.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:4",
+            "modificationTime": "2019-12-03T11:40:45.776329Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_4_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk4.patch"
+            ],
+            "version": "=0.2.0"
+          },
+          {
+            "comments": [],
+            "id": "patch:npm:ms:20151024:5",
+            "modificationTime": "2019-12-03T11:40:45.777474Z",
+            "urls": [
+              "https://snyk-patches.s3.amazonaws.com/npm/ms/20151024/ms_20151024_5_0_48701f029417faf65e6f5e0b61a3cebe5436b07b_snyk5.patch"
+            ],
+            "version": "=0.1.0"
+          }
+        ],
+        "publicationTime": "2015-11-06T02:09:36Z",
+        "references": [
+          {
+            "title": "OSS security Advisory",
+            "url": "https://www.openwall.com/lists/oss-security/2016/04/20/11"
+          },
+          {
+            "title": "OWASP - ReDoS",
+            "url": "https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS"
+          },
+          {
+            "title": "Security Focus",
+            "url": "https://www.securityfocus.com/bid/96389"
+          }
+        ],
+        "semver": {
+          "vulnerable": [
+            "<0.7.1"
+          ]
+        },
+        "severity": "medium",
+        "title": "Regular Expression Denial of Service (ReDoS)",
+        "from": [
+          "goof@0.0.3",
+          "humanize-ms@1.0.1",
+          "ms@0.6.2"
+        ],
+        "upgradePath": [
+          false,
+          "humanize-ms@1.0.2",
+          "ms@0.7.1"
+        ],
+        "isUpgradable": true,
+        "isPatchable": true,
+        "name": "ms",
+        "version": "0.6.2",
+        "filtered": {
+          "patches": [
+            {
+              "patched": "2019-09-23T21:21:17.183Z",
+              "path": [
+                "humanize-ms",
+                "ms"
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  },
+  "uniqueCount": 10,
+  "projectName": "unmonitored-goof",
+  "displayTargetFile": "package-lock.json",
+  "path": "/home/antoine/Documents/SnykSB/goof"
+}

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -183,4 +183,38 @@ describe('Test End 2 End - Inline mode', () => {
     // => When testing, loaded as module therefore returning code === process.exitCode
     expect(result).toEqual(0);
   });
+
+  it('Test Inline mode strict mode - no monitored project found - return vulns and 1 exit code', async () => {
+    setTimeout(() => {
+      stdinMock.send(
+        fs
+          .readFileSync(
+            fixturesFolderPath + 'snykTestsOutputs/test-unmonitored-goof.json',
+          )
+          .toString(),
+      );
+      stdinMock.send(null);
+    }, 100);
+
+    const result = await getDelta();
+
+    const expectedOutput = [
+      'New issue introduced !',
+      'Security Vulnerability:',
+      '  1/1: Regular Expression Denial of Service (ReDoS) [High Severity]',
+      '    Via: @snyk/nodejs-runtime-agent@1.14.0 => acorn@5.7.3',
+      '    Fixed in: acorn 5.7.4, 6.4.1, 7.1.1',
+      '    Fixable by upgrade:  @snyk/nodejs-runtime-agent@1.14.0=>acorn@5.7.4',
+      '   ',
+      'New issue introduced !',
+      'License Issue:',
+      '  1/1: GPL-2.0 license [Medium Severity]',
+    ];
+    expectedOutput.forEach((line: string) => {
+      expect(consoleOutput.join()).toContain(line);
+    });
+    //expect(mockExit).toHaveBeenCalledWith(0);
+    // => When testing, loaded as module therefore returning code === process.exitCode
+    expect(result).toEqual(1);
+  });
 });

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -61,19 +61,12 @@ describe('Test endpoint functions', () => {
   });
 
   it('Test GetProjectUUID not found', async () => {
-    try {
-      const project = await getProjectUUID(
-        '689ce7f9-7943-4a71-b704-2ba575f01089',
-        'whatever',
-        'cli',
-      );
-      expect(project).toThrow();
-    } catch (err) {
-      expect(err).toBeInstanceOf(Error.NotFoundError);
-      expect(err.message).toContain(
-        'Snyk API - Could not find a monitored project matching.',
-      );
-    }
+    const project = await getProjectUUID(
+      '689ce7f9-7943-4a71-b704-2ba575f01089',
+      'whatever',
+      'cli',
+    );
+    expect(project).toEqual('');
   });
 
   it('Test GetProjectUUID not unique found', async () => {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Makes snyk-delta runs return the snyk test output if no monitored projects can be found, instead of throwing an error.

### Notes for the reviewer

It seems to be the desired behavior of most users.

