### PR TITLE
fix: remove first expected bool val from upgradepaths array

### DIFF
--- a/src/lib/snyk/issues.ts
+++ b/src/lib/snyk/issues.ts
@@ -32,8 +32,10 @@ const getNewIssues = (
   MonitoredIssues.forEach((monitoredIssue) => {
     newIssues = _.reject(newIssues, (issue) => {
       let issueFromArray = issue.from;
+      let upgradePathArray = issue.upgradePath
       if (mode == 'inline') {
         issueFromArray = issueFromArray.slice(1, issueFromArray.length);
+        upgradePathArray = upgradePathArray? upgradePathArray.slice(1, issueFromArray.length):undefined;
       }
 
       return (


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Removes the first boolean value from the upgradePaths array in the cli output for inline mode.
