### PR TITLE
fix: lookup pkdId using nodeId as they are different

### DIFF
--- a/src/lib/snyk/dependencies.ts
+++ b/src/lib/snyk/dependencies.ts
@@ -1,155 +1,228 @@
-import * as depgraph from '@snyk/dep-graph'
-import * as _ from 'lodash'
-import * as chalk from 'chalk'
-import {getIssuesDetailsPerPackage} from '../snyk/issues'
-import { IssueWithPaths } from '../types'
+import * as depgraph from '@snyk/dep-graph';
+import * as _ from 'lodash';
+import * as chalk from 'chalk';
+import { getIssuesDetailsPerPackage } from '../snyk/issues';
+import { IssueWithPaths } from '../types';
 
-const displayDependenciesChangeDetails = async (snykDepsJsonResults: any, monitoredProjectDepGraph: any, packageManager: string, newVulns: IssueWithPaths[], newLicenseIssues: IssueWithPaths[]) => {
-    let snykTestGraph: depgraph.DepGraph
-    if(snykDepsJsonResults && snykDepsJsonResults.depGraph){ // Getting graph
-        
-        snykTestGraph = depgraph.createFromJSON(snykDepsJsonResults.depGraph)
-    } else { // Getting legacy dep tree
-        snykTestGraph = await depgraph.legacy.depTreeToGraph(snykDepsJsonResults as depgraph.legacy.DepTree, packageManager)
+const displayDependenciesChangeDetails = async (
+  snykDepsJsonResults: any,
+  monitoredProjectDepGraph: any,
+  packageManager: string,
+  newVulns: IssueWithPaths[],
+  newLicenseIssues: IssueWithPaths[],
+) => {
+  let snykTestGraph: depgraph.DepGraph;
+  if (snykDepsJsonResults && snykDepsJsonResults.depGraph) {
+    // Getting graph
+
+    snykTestGraph = depgraph.createFromJSON(snykDepsJsonResults.depGraph);
+  } else {
+    // Getting legacy dep tree
+    snykTestGraph = await depgraph.legacy.depTreeToGraph(
+      snykDepsJsonResults as depgraph.legacy.DepTree,
+      packageManager,
+    );
+  }
+
+  const snykTestDirectDepsNodeIDs = snykTestGraph
+    .toJSON()
+    .graph.nodes[0].deps.map((dep) => dep.nodeId);
+  const snykTestDirectDepsPkgIDs: Array<string> = [];
+
+  snykTestDirectDepsNodeIDs.forEach((nodeId) => {
+    const node = snykTestGraph
+      .toJSON()
+      .graph.nodes.find((node) => node.nodeId == nodeId);
+    if (!node) {
+      throw new Error(`Could not find node in graph ${nodeId}`);
+    } else {
+      snykTestDirectDepsPkgIDs.push(node.pkgId);
     }
-    
-    //const snykTestDeps = snykTestGraph.getPkgs()
-    const snykTestDirectDepsNodeIDs = snykTestGraph.toJSON().graph.nodes[0].deps.map(dep => dep.nodeId)
-    const snykTestDirectDepsPkgIDs: Array<string> = []
-    
-        snykTestDirectDepsNodeIDs.forEach(nodeId => {
-            const node = snykTestGraph.toJSON().graph.nodes.find(node => node.nodeId == nodeId)
-            if(!node){
-                throw new Error(`Could not find node in graph ${nodeId}`)
-            } else {
-                snykTestDirectDepsPkgIDs.push(node.pkgId)
-            }
-            
-        })
-    
-    
+  });
 
-    const snykTestDirectDeps = snykTestGraph.toJSON().pkgs.filter(pkg => snykTestDirectDepsPkgIDs.indexOf(pkg.id) > 0)
-    const snykTestIndirectDeps = snykTestGraph.toJSON().pkgs.filter(pkg => snykTestDirectDepsPkgIDs.indexOf(pkg.id) <= 0)
-    
-    const snykProjectGraph = depgraph.createFromJSON(monitoredProjectDepGraph.depGraph as depgraph.DepGraphData)
+  const snykTestDirectDeps = snykTestGraph
+    .toJSON()
+    .pkgs.filter((pkg) => snykTestDirectDepsPkgIDs.indexOf(pkg.id) > 0);
+  const snykTestIndirectDeps = snykTestGraph
+    .toJSON()
+    .pkgs.filter((pkg) => snykTestDirectDepsPkgIDs.indexOf(pkg.id) <= 0);
 
-    const snykProjectDirectDepsNodeIDs = snykProjectGraph.toJSON().graph.nodes[0].deps.map(dep => dep.nodeId)
+  const snykProjectGraph = depgraph.createFromJSON(
+    monitoredProjectDepGraph.depGraph as depgraph.DepGraphData,
+  );
 
-    const snykProjectDirectDepsPkgIDs: Array<string> = []
-    
-    snykProjectDirectDepsNodeIDs.forEach(nodeId => {
-        const node = snykProjectGraph.toJSON().graph.nodes.find(node => node.nodeId == nodeId)
-        if(!node){
-            throw new Error(`Could not find node in graph ${nodeId}`)
-        } else {
-            snykProjectDirectDepsPkgIDs.push(node.pkgId)
-        }
-        
-    })
+  const snykProjectDirectDepsNodeIDs = snykProjectGraph
+    .toJSON()
+    .graph.nodes[0].deps.map((dep) => dep.nodeId);
 
-    const snykProjectDirectDeps = snykProjectGraph.toJSON().pkgs.filter(pkg => snykProjectDirectDepsPkgIDs.indexOf(pkg.id) > 0)
-    const snykProjectIndirectDeps =snykProjectGraph.toJSON().pkgs.filter(pkg => snykProjectDirectDepsPkgIDs.indexOf(pkg.id) <= 0)
+  const snykProjectDirectDepsPkgIDs: Array<string> = [];
 
-    const addedDirectDeps = _.differenceWith(snykTestDirectDeps, snykProjectDirectDeps,_.isEqual)
-    const removedDirectDeps = _.differenceWith(snykProjectDirectDeps, snykTestDirectDeps,_.isEqual)
+  snykProjectDirectDepsNodeIDs.forEach((nodeId) => {
+    const node = snykProjectGraph
+      .toJSON()
+      .graph.nodes.find((node) => node.nodeId == nodeId);
+    if (!node) {
+      throw new Error(`Could not find node in graph ${nodeId}`);
+    } else {
+      snykProjectDirectDepsPkgIDs.push(node.pkgId);
+    }
+  });
 
-    const addedIndirectDeps = _.differenceWith(snykTestIndirectDeps, snykProjectIndirectDeps,_.isEqual)
-    const removedIndirectDeps = _.differenceWith(snykProjectIndirectDeps, snykTestIndirectDeps,_.isEqual)
+  const snykProjectDirectDeps = snykProjectGraph
+    .toJSON()
+    .pkgs.filter((pkg) => snykProjectDirectDepsPkgIDs.indexOf(pkg.id) > 0);
+  const snykProjectIndirectDeps = snykProjectGraph
+    .toJSON()
+    .pkgs.filter((pkg) => snykProjectDirectDepsPkgIDs.indexOf(pkg.id) <= 0);
 
+  const addedDirectDeps = _.differenceWith(
+    snykTestDirectDeps,
+    snykProjectDirectDeps,
+    _.isEqual,
+  );
+  const removedDirectDeps = _.differenceWith(
+    snykProjectDirectDeps,
+    snykTestDirectDeps,
+    _.isEqual,
+  );
 
-    console.log("_____________________________")
-    console.log("Direct deps:")
-    console.log(`Added ${addedDirectDeps.length} \n`+addedDirectDeps.map(dep => dep.id))
-    console.log("===============")
-    console.log(`Removed ${removedDirectDeps.length}\n`+removedDirectDeps.map(dep => dep.id))
-    console.log("##################")
-    console.log("Indirect deps:")
-    console.log(`Added ${addedIndirectDeps.length} \n`+addedIndirectDeps.map(dep => dep.id))
-    console.log("===============")
-    console.log("Paths")
-    
-    
-    
-    const consolidatedIndirectlyAddedDepsPaths = consolidateIndirectDepsPaths(addedIndirectDeps,snykTestGraph)
-    addedIndirectDeps.forEach(addedDep => {
-        
-        //Display all the indirect deps and their paths
-        let allPathsForGivenDep = consolidatedIndirectlyAddedDepsPaths.get(addedDep.id)
-        //let depNameFormatted = arePathsRemoved? chalk.strikethrough(indirectDep.id): addedDep.id
-        let vulnsForDep = getIssuesDetailsPerPackage(newVulns, addedDep.info.name, addedDep.info.version)
-        
-        const vulnsCount = vulnsForDep.length
-         //let d =` - ${(vulnsForDep.length > 0? chalk.redBright(vulnsForDep.length+' vuln(s)'): '0 vuln')}`
-        if(allPathsForGivenDep){
-            let count = ''
-            let paths = '     '+allPathsForGivenDep.map(pathArr=>pathArr.join('=>')).join('\n       ')
-            switch(vulnsCount){
-                case 0:
-                    count = 'no issue'
-                    paths = chalk.blue(paths)
-                    break;
-                case 1:
-                    count = chalk.redBright('1 issue')
-                default:
-                    count = chalk.redBright(vulnsCount+' issue')
-                    paths = chalk.redBright(paths)
-            }
-            
-            console.log('   '+addedDep.id+' '+count+ ''+ ':\n'+paths)
-        }
-    })
-    
+  const addedIndirectDeps = _.differenceWith(
+    snykTestIndirectDeps,
+    snykProjectIndirectDeps,
+    _.isEqual,
+  );
+  const removedIndirectDeps = _.differenceWith(
+    snykProjectIndirectDeps,
+    snykTestIndirectDeps,
+    _.isEqual,
+  );
 
-    //console.log(snykTestAddedIndirectDepsPaths)
-    console.log("===============")
-    console.log(`Removed ${removedIndirectDeps.length}\n`,removedIndirectDeps.map(dep => dep.id))
-    console.log("_____________________________")
-    // console.log(chalk.strikethrough(addedDirectDeps))
-     // TODO - Dep stats
-      // health risk
-      // internal usage
+  console.log('_____________________________');
+  console.log('Direct deps:');
+  console.log(
+    `Added ${addedDirectDeps.length} \n` + addedDirectDeps.map((dep) => dep.id),
+  );
+  console.log('===============');
+  console.log(
+    `Removed ${removedDirectDeps.length}\n` +
+      removedDirectDeps.map((dep) => dep.id),
+  );
+  console.log('##################');
+  console.log('Indirect deps:');
+  console.log(
+    `Added ${addedIndirectDeps.length} \n` +
+      addedIndirectDeps.map((dep) => dep.id),
+  );
+  console.log('===============');
+  console.log('Paths');
 
-      // popularity
-      // ranking
-      // allowed/not allowed
-     // displayIndirectDepsConsolidatedPath(removedIndirectDeps,snykProjectGraph, true)
+  const consolidatedIndirectlyAddedDepsPaths = consolidateIndirectDepsPaths(
+    addedIndirectDeps,
+    snykTestGraph,
+  );
+  addedIndirectDeps.forEach((addedDep) => {
+    //Display all the indirect deps and their paths
+    let allPathsForGivenDep = consolidatedIndirectlyAddedDepsPaths.get(
+      addedDep.id,
+    );
 
-     const consolidatedIndirectlyRemovedDepsPaths = consolidateIndirectDepsPaths(removedIndirectDeps,snykProjectGraph)
-     addedIndirectDeps.forEach(removedDep => {
-         //Display all the indirect deps and their paths
-         let allPathsForGivenDep = consolidatedIndirectlyRemovedDepsPaths.get(removedDep.id)
-         if(allPathsForGivenDep){
-             console.log('   ',chalk.strikethrough(removedDep.id), ':\n',chalk.blue('     ',allPathsForGivenDep.map(pathArr=>pathArr.join('=>')).join('\n       ')))
-         }
-     })
-}
+    let vulnsForDep = getIssuesDetailsPerPackage(
+      newVulns,
+      addedDep.info.name,
+      addedDep.info.version,
+    );
 
-const consolidateIndirectDepsPaths = (listOfDeps: Array<any>, snykTestGraph: depgraph.DepGraph): Map<string,string[][]> => {
-    let snykIndirectDepsPaths = new Map<string,Array<Array<string>>>()
-    listOfDeps.forEach(indirectDep => {
-        snykTestGraph.pkgPathsToRoot(indirectDep.info).forEach(individualPath => {
-            // Group all paths for a given indirect dep together in a map
-            let individualPathFormatted = individualPath.reverse().slice(1).map(pkgInfo => pkgInfo.name+'@'+pkgInfo.version)
-            if(snykIndirectDepsPaths.has(indirectDep.id)){
-                let pathsArray = snykIndirectDepsPaths.get(indirectDep.id) as Array<Array<string>>
-                pathsArray.push(individualPathFormatted)
-                snykIndirectDepsPaths.set(indirectDep.id, pathsArray)
-                
-            } else{
-                let pathsArray: Array<Array<string>> = new Array()
-                pathsArray.push(individualPathFormatted)
-                snykIndirectDepsPaths.set(indirectDep.id, pathsArray)
-            }
-            
-        })
-    
-    })
-    
-    return snykIndirectDepsPaths    
-}
-export {
-    displayDependenciesChangeDetails,
-    consolidateIndirectDepsPaths,
+    const vulnsCount = vulnsForDep.length;
 
-}
+    if (allPathsForGivenDep) {
+      let count = '';
+      let paths =
+        '     ' +
+        allPathsForGivenDep
+          .map((pathArr) => pathArr.join('=>'))
+          .join('\n       ');
+      switch (vulnsCount) {
+        case 0:
+          count = 'no issue';
+          paths = chalk.blue(paths);
+          break;
+        case 1:
+          count = chalk.redBright('1 issue');
+        default:
+          count = chalk.redBright(vulnsCount + ' issue');
+          paths = chalk.redBright(paths);
+      }
+
+      console.log('   ' + addedDep.id + ' ' + count + '' + ':\n' + paths);
+    }
+  });
+
+  console.log('===============');
+  console.log(
+    `Removed ${removedIndirectDeps.length}\n`,
+    removedIndirectDeps.map((dep) => dep.id),
+  );
+  console.log('_____________________________');
+
+  // TODO - Dep stats
+  // health risk
+  // internal usage
+
+  // popularity
+  // ranking
+  // allowed/not allowed
+
+  const consolidatedIndirectlyRemovedDepsPaths = consolidateIndirectDepsPaths(
+    removedIndirectDeps,
+    snykProjectGraph,
+  );
+  addedIndirectDeps.forEach((removedDep) => {
+    //Display all the indirect deps and their paths
+    let allPathsForGivenDep = consolidatedIndirectlyRemovedDepsPaths.get(
+      removedDep.id,
+    );
+    if (allPathsForGivenDep) {
+      console.log(
+        '   ',
+        chalk.strikethrough(removedDep.id),
+        ':\n',
+        chalk.blue(
+          '     ',
+          allPathsForGivenDep
+            .map((pathArr) => pathArr.join('=>'))
+            .join('\n       '),
+        ),
+      );
+    }
+  });
+};
+
+const consolidateIndirectDepsPaths = (
+  listOfDeps: Array<any>,
+  snykTestGraph: depgraph.DepGraph,
+): Map<string, string[][]> => {
+  let snykIndirectDepsPaths = new Map<string, Array<Array<string>>>();
+  listOfDeps.forEach((indirectDep) => {
+    snykTestGraph.pkgPathsToRoot(indirectDep.info).forEach((individualPath) => {
+      // Group all paths for a given indirect dep together in a map
+      let individualPathFormatted = individualPath
+        .reverse()
+        .slice(1)
+        .map((pkgInfo) => pkgInfo.name + '@' + pkgInfo.version);
+      if (snykIndirectDepsPaths.has(indirectDep.id)) {
+        let pathsArray = snykIndirectDepsPaths.get(indirectDep.id) as Array<
+          Array<string>
+        >;
+        pathsArray.push(individualPathFormatted);
+        snykIndirectDepsPaths.set(indirectDep.id, pathsArray);
+      } else {
+        let pathsArray: Array<Array<string>> = new Array();
+        pathsArray.push(individualPathFormatted);
+        snykIndirectDepsPaths.set(indirectDep.id, pathsArray);
+      }
+    });
+  });
+
+  return snykIndirectDepsPaths;
+};
+export { displayDependenciesChangeDetails, consolidateIndirectDepsPaths };

--- a/test/fixtures/apiResponses/poetry-depgraph.json
+++ b/test/fixtures/apiResponses/poetry-depgraph.json
@@ -1,0 +1,459 @@
+{
+  "depGraph": {
+    "schemaVersion": "1.2.0",
+    "pkgManager": { "name": "poetry" },
+    "pkgs": [
+      {
+        "id": "poetry@1.2.6",
+        "info": { "name": "poetry", "version": "1.2.6" }
+      },
+      {
+        "id": "coverage@4.5.2",
+        "info": { "name": "coverage", "version": "4.5.2" }
+      },
+      {
+        "id": "django@2.2.16",
+        "info": { "name": "django", "version": "2.2.16" }
+      },
+      { "id": "pytz@2019.1", "info": { "name": "pytz", "version": "2019.1" } },
+      {
+        "id": "sqlparse@0.3.0",
+        "info": { "name": "sqlparse", "version": "0.3.0" }
+      },
+      {
+        "id": "django-cors-headers@2.4.0",
+        "info": { "name": "django-cors-headers", "version": "2.4.0" }
+      },
+      {
+        "id": "django-environ@0.4.5",
+        "info": { "name": "django-environ", "version": "0.4.5" }
+      },
+      {
+        "id": "django-filter@2.0.0",
+        "info": { "name": "django-filter", "version": "2.0.0" }
+      },
+      {
+        "id": "djangorestframework@3.9.4",
+        "info": { "name": "djangorestframework", "version": "3.9.4" }
+      },
+      {
+        "id": "psycopg2cffi@2.8.1",
+        "info": { "name": "psycopg2cffi", "version": "2.8.1" }
+      },
+      { "id": "cffi@1.14.5", "info": { "name": "cffi", "version": "1.14.5" } },
+      {
+        "id": "pycparser@2.19",
+        "info": { "name": "pycparser", "version": "2.19" }
+      },
+      { "id": "six@1.12.0", "info": { "name": "six", "version": "1.12.0" } },
+      { "id": "pyyaml@5.4", "info": { "name": "pyyaml", "version": "5.4" } },
+      { "id": "redis@3.0.1", "info": { "name": "redis", "version": "3.0.1" } },
+      {
+        "id": "requests@2.20.1",
+        "info": { "name": "requests", "version": "2.20.1" }
+      },
+      {
+        "id": "certifi@2019.6.16",
+        "info": { "name": "certifi", "version": "2019.6.16" }
+      },
+      {
+        "id": "chardet@3.0.4",
+        "info": { "name": "chardet", "version": "3.0.4" }
+      },
+      { "id": "idna@2.7", "info": { "name": "idna", "version": "2.7" } },
+      {
+        "id": "urllib3@1.24.3",
+        "info": { "name": "urllib3", "version": "1.24.3" }
+      },
+      {
+        "id": "social-auth-app-django@4.0.0",
+        "info": { "name": "social-auth-app-django", "version": "4.0.0" }
+      },
+      {
+        "id": "social-auth-core@3.3.3",
+        "info": { "name": "social-auth-core", "version": "3.3.3" }
+      },
+      {
+        "id": "cryptography@3.3.2",
+        "info": { "name": "cryptography", "version": "3.3.2" }
+      },
+      {
+        "id": "defusedxml@0.7.0rc1",
+        "info": { "name": "defusedxml", "version": "0.7.0rc1" }
+      },
+      {
+        "id": "oauthlib@3.0.2",
+        "info": { "name": "oauthlib", "version": "3.0.2" }
+      },
+      { "id": "pyjwt@1.7.1", "info": { "name": "pyjwt", "version": "1.7.1" } },
+      {
+        "id": "python3-openid@3.1.0",
+        "info": { "name": "python3-openid", "version": "3.1.0" }
+      },
+      {
+        "id": "requests-oauthlib@1.2.0",
+        "info": { "name": "requests-oauthlib", "version": "1.2.0" }
+      },
+      {
+        "id": "pyngboard@0.0.6",
+        "info": { "name": "pyngboard", "version": "0.0.6" }
+      },
+      {
+        "id": "django-extensions@2.1.6",
+        "info": { "name": "django-extensions", "version": "2.1.6" }
+      },
+      {
+        "id": "uwsgi@2.0.18",
+        "info": { "name": "uwsgi", "version": "2.0.18" }
+      },
+      {
+        "id": "stringcase@1.2.0",
+        "info": { "name": "stringcase", "version": "1.2.0" }
+      },
+      {
+        "id": "werkzeug@0.15.2",
+        "info": { "name": "werkzeug", "version": "0.15.2" }
+      },
+      {
+        "id": "django-bootstrap4@0.0.8",
+        "info": { "name": "django-bootstrap4", "version": "0.0.8" }
+      },
+      {
+        "id": "django-import-export@1.2.0",
+        "info": { "name": "django-import-export", "version": "1.2.0" }
+      },
+      {
+        "id": "diff-match-patch@20181111",
+        "info": { "name": "diff-match-patch", "version": "20181111" }
+      },
+      {
+        "id": "tablib@0.13.0",
+        "info": { "name": "tablib", "version": "0.13.0" }
+      },
+      {
+        "id": "backports.csv@1.0.7",
+        "info": { "name": "backports.csv", "version": "1.0.7" }
+      },
+      { "id": "odfpy@1.4.0", "info": { "name": "odfpy", "version": "1.4.0" } },
+      {
+        "id": "openpyxl@2.6.2",
+        "info": { "name": "openpyxl", "version": "2.6.2" }
+      },
+      {
+        "id": "et-xmlfile@1.0.1",
+        "info": { "name": "et-xmlfile", "version": "1.0.1" }
+      },
+      { "id": "jdcal@1.4.1", "info": { "name": "jdcal", "version": "1.4.1" } },
+      { "id": "xlrd@1.2.0", "info": { "name": "xlrd", "version": "1.2.0" } },
+      { "id": "xlwt@1.3.0", "info": { "name": "xlwt", "version": "1.3.0" } },
+      {
+        "id": "sentry-sdk@0.7.14",
+        "info": { "name": "sentry-sdk", "version": "0.7.14" }
+      },
+      {
+        "id": "django-health-check@3.11.1",
+        "info": { "name": "django-health-check", "version": "3.11.1" }
+      },
+      { "id": "retry@0.9.2", "info": { "name": "retry", "version": "0.9.2" } },
+      {
+        "id": "decorator@4.4.0",
+        "info": { "name": "decorator", "version": "4.4.0" }
+      },
+      { "id": "py@1.8.0", "info": { "name": "py", "version": "1.8.0" } },
+      {
+        "id": "django-oauth-toolkit@1.3.2",
+        "info": { "name": "django-oauth-toolkit", "version": "1.3.2" }
+      },
+      {
+        "id": "python-jose@3.2.0",
+        "info": { "name": "python-jose", "version": "3.2.0" }
+      },
+      {
+        "id": "ecdsa@0.14.1",
+        "info": { "name": "ecdsa", "version": "0.14.1" }
+      },
+      {
+        "id": "pyasn1@0.4.8",
+        "info": { "name": "pyasn1", "version": "0.4.8" }
+      },
+      { "id": "rsa@4.6", "info": { "name": "rsa", "version": "4.6" } },
+      {
+        "id": "core-logging@2.2.0",
+        "info": { "name": "core-logging", "version": "2.2.0" }
+      },
+      {
+        "id": "django-ipware@2.1.0",
+        "info": { "name": "django-ipware", "version": "2.1.0" }
+      },
+      {
+        "id": "json-log-formatter@0.2.0",
+        "info": { "name": "json-log-formatter", "version": "0.2.0" }
+      },
+      {
+        "id": "slack-sdk@3.1.0",
+        "info": { "name": "slack-sdk", "version": "3.1.0" }
+      }
+    ],
+    "graph": {
+      "rootNodeId": "root-node",
+      "nodes": [
+        {
+          "nodeId": "root-node",
+          "pkgId": "poetry@1.2.6",
+          "deps": [
+            { "nodeId": "coverage" },
+            { "nodeId": "django" },
+            { "nodeId": "django-cors-headers" },
+            { "nodeId": "django-environ" },
+            { "nodeId": "django-filter" },
+            { "nodeId": "djangorestframework" },
+            { "nodeId": "psycopg2cffi" },
+            { "nodeId": "pyyaml" },
+            { "nodeId": "redis" },
+            { "nodeId": "requests" },
+            { "nodeId": "social-auth-app-django" },
+            { "nodeId": "pyngboard" },
+            { "nodeId": "django-extensions" },
+            { "nodeId": "uwsgi" },
+            { "nodeId": "stringcase" },
+            { "nodeId": "werkzeug" },
+            { "nodeId": "django-bootstrap4" },
+            { "nodeId": "django-import-export" },
+            { "nodeId": "sentry-sdk" },
+            { "nodeId": "django-health-check" },
+            { "nodeId": "retry" },
+            { "nodeId": "django-oauth-toolkit" },
+            { "nodeId": "python-jose" },
+            { "nodeId": "social-auth-core" },
+            { "nodeId": "core-logging" },
+            { "nodeId": "slack-sdk" },
+            { "nodeId": "cffi" },
+            { "nodeId": "cryptography" }
+          ]
+        },
+        { "nodeId": "coverage", "pkgId": "coverage@4.5.2", "deps": [] },
+        {
+          "nodeId": "django",
+          "pkgId": "django@2.2.16",
+          "deps": [{ "nodeId": "pytz" }, { "nodeId": "sqlparse" }]
+        },
+        { "nodeId": "pytz", "pkgId": "pytz@2019.1", "deps": [] },
+        { "nodeId": "sqlparse", "pkgId": "sqlparse@0.3.0", "deps": [] },
+        {
+          "nodeId": "django-cors-headers",
+          "pkgId": "django-cors-headers@2.4.0",
+          "deps": []
+        },
+        {
+          "nodeId": "django-environ",
+          "pkgId": "django-environ@0.4.5",
+          "deps": []
+        },
+        {
+          "nodeId": "django-filter",
+          "pkgId": "django-filter@2.0.0",
+          "deps": [{ "nodeId": "django" }]
+        },
+        {
+          "nodeId": "djangorestframework",
+          "pkgId": "djangorestframework@3.9.4",
+          "deps": []
+        },
+        {
+          "nodeId": "psycopg2cffi",
+          "pkgId": "psycopg2cffi@2.8.1",
+          "deps": [{ "nodeId": "cffi" }, { "nodeId": "six" }]
+        },
+        {
+          "nodeId": "cffi",
+          "pkgId": "cffi@1.14.5",
+          "deps": [{ "nodeId": "pycparser" }]
+        },
+        { "nodeId": "pycparser", "pkgId": "pycparser@2.19", "deps": [] },
+        { "nodeId": "six", "pkgId": "six@1.12.0", "deps": [] },
+        { "nodeId": "pyyaml", "pkgId": "pyyaml@5.4", "deps": [] },
+        { "nodeId": "redis", "pkgId": "redis@3.0.1", "deps": [] },
+        {
+          "nodeId": "requests",
+          "pkgId": "requests@2.20.1",
+          "deps": [
+            { "nodeId": "certifi" },
+            { "nodeId": "chardet" },
+            { "nodeId": "idna" },
+            { "nodeId": "urllib3" }
+          ]
+        },
+        { "nodeId": "certifi", "pkgId": "certifi@2019.6.16", "deps": [] },
+        { "nodeId": "chardet", "pkgId": "chardet@3.0.4", "deps": [] },
+        { "nodeId": "idna", "pkgId": "idna@2.7", "deps": [] },
+        { "nodeId": "urllib3", "pkgId": "urllib3@1.24.3", "deps": [] },
+        {
+          "nodeId": "social-auth-app-django",
+          "pkgId": "social-auth-app-django@4.0.0",
+          "deps": [{ "nodeId": "six" }, { "nodeId": "social-auth-core" }]
+        },
+        {
+          "nodeId": "social-auth-core",
+          "pkgId": "social-auth-core@3.3.3",
+          "deps": [
+            { "nodeId": "cryptography" },
+            { "nodeId": "defusedxml" },
+            { "nodeId": "oauthlib" },
+            { "nodeId": "pyjwt" },
+            { "nodeId": "python3-openid" },
+            { "nodeId": "requests" },
+            { "nodeId": "requests-oauthlib" },
+            { "nodeId": "six" }
+          ]
+        },
+        {
+          "nodeId": "cryptography",
+          "pkgId": "cryptography@3.3.2",
+          "deps": [{ "nodeId": "cffi" }, { "nodeId": "six" }]
+        },
+        { "nodeId": "defusedxml", "pkgId": "defusedxml@0.7.0rc1", "deps": [] },
+        { "nodeId": "oauthlib", "pkgId": "oauthlib@3.0.2", "deps": [] },
+        { "nodeId": "pyjwt", "pkgId": "pyjwt@1.7.1", "deps": [] },
+        {
+          "nodeId": "python3-openid",
+          "pkgId": "python3-openid@3.1.0",
+          "deps": [{ "nodeId": "defusedxml" }]
+        },
+        {
+          "nodeId": "requests-oauthlib",
+          "pkgId": "requests-oauthlib@1.2.0",
+          "deps": [{ "nodeId": "oauthlib" }, { "nodeId": "requests" }]
+        },
+        {
+          "nodeId": "pyngboard",
+          "pkgId": "pyngboard@0.0.6",
+          "deps": [{ "nodeId": "requests" }, { "nodeId": "requests-oauthlib" }]
+        },
+        {
+          "nodeId": "django-extensions",
+          "pkgId": "django-extensions@2.1.6",
+          "deps": [{ "nodeId": "six" }]
+        },
+        { "nodeId": "uwsgi", "pkgId": "uwsgi@2.0.18", "deps": [] },
+        { "nodeId": "stringcase", "pkgId": "stringcase@1.2.0", "deps": [] },
+        { "nodeId": "werkzeug", "pkgId": "werkzeug@0.15.2", "deps": [] },
+        {
+          "nodeId": "django-bootstrap4",
+          "pkgId": "django-bootstrap4@0.0.8",
+          "deps": []
+        },
+        {
+          "nodeId": "django-import-export",
+          "pkgId": "django-import-export@1.2.0",
+          "deps": [
+            { "nodeId": "diff-match-patch" },
+            { "nodeId": "django" },
+            { "nodeId": "tablib" }
+          ]
+        },
+        {
+          "nodeId": "diff-match-patch",
+          "pkgId": "diff-match-patch@20181111",
+          "deps": []
+        },
+        {
+          "nodeId": "tablib",
+          "pkgId": "tablib@0.13.0",
+          "deps": [
+            { "nodeId": "backports.csv" },
+            { "nodeId": "odfpy" },
+            { "nodeId": "openpyxl" },
+            { "nodeId": "pyyaml" },
+            { "nodeId": "xlrd" },
+            { "nodeId": "xlwt" }
+          ]
+        },
+        {
+          "nodeId": "backports.csv",
+          "pkgId": "backports.csv@1.0.7",
+          "deps": []
+        },
+        {
+          "nodeId": "odfpy",
+          "pkgId": "odfpy@1.4.0",
+          "deps": [{ "nodeId": "defusedxml" }]
+        },
+        {
+          "nodeId": "openpyxl",
+          "pkgId": "openpyxl@2.6.2",
+          "deps": [{ "nodeId": "et-xmlfile" }, { "nodeId": "jdcal" }]
+        },
+        { "nodeId": "et-xmlfile", "pkgId": "et-xmlfile@1.0.1", "deps": [] },
+        { "nodeId": "jdcal", "pkgId": "jdcal@1.4.1", "deps": [] },
+        { "nodeId": "xlrd", "pkgId": "xlrd@1.2.0", "deps": [] },
+        { "nodeId": "xlwt", "pkgId": "xlwt@1.3.0", "deps": [] },
+        {
+          "nodeId": "sentry-sdk",
+          "pkgId": "sentry-sdk@0.7.14",
+          "deps": [{ "nodeId": "certifi" }, { "nodeId": "urllib3" }]
+        },
+        {
+          "nodeId": "django-health-check",
+          "pkgId": "django-health-check@3.11.1",
+          "deps": [{ "nodeId": "django" }]
+        },
+        {
+          "nodeId": "retry",
+          "pkgId": "retry@0.9.2",
+          "deps": [{ "nodeId": "decorator" }, { "nodeId": "py" }]
+        },
+        { "nodeId": "decorator", "pkgId": "decorator@4.4.0", "deps": [] },
+        { "nodeId": "py", "pkgId": "py@1.8.0", "deps": [] },
+        {
+          "nodeId": "django-oauth-toolkit",
+          "pkgId": "django-oauth-toolkit@1.3.2",
+          "deps": [
+            { "nodeId": "django" },
+            { "nodeId": "oauthlib" },
+            { "nodeId": "requests" }
+          ]
+        },
+        {
+          "nodeId": "python-jose",
+          "pkgId": "python-jose@3.2.0",
+          "deps": [
+            { "nodeId": "ecdsa" },
+            { "nodeId": "pyasn1" },
+            { "nodeId": "rsa" },
+            { "nodeId": "six" }
+          ]
+        },
+        {
+          "nodeId": "ecdsa",
+          "pkgId": "ecdsa@0.14.1",
+          "deps": [{ "nodeId": "six" }]
+        },
+        { "nodeId": "pyasn1", "pkgId": "pyasn1@0.4.8", "deps": [] },
+        {
+          "nodeId": "rsa",
+          "pkgId": "rsa@4.6",
+          "deps": [{ "nodeId": "pyasn1" }]
+        },
+        {
+          "nodeId": "core-logging",
+          "pkgId": "core-logging@2.2.0",
+          "deps": [
+            { "nodeId": "django-ipware" },
+            { "nodeId": "json-log-formatter" }
+          ]
+        },
+        {
+          "nodeId": "django-ipware",
+          "pkgId": "django-ipware@2.1.0",
+          "deps": []
+        },
+        {
+          "nodeId": "json-log-formatter",
+          "pkgId": "json-log-formatter@0.2.0",
+          "deps": []
+        },
+        { "nodeId": "slack-sdk", "pkgId": "slack-sdk@3.1.0", "deps": [] }
+      ]
+    }
+  }
+}

--- a/test/fixtures/apiResponses/test-poetry.json
+++ b/test/fixtures/apiResponses/test-poetry.json
@@ -1,0 +1,11 @@
+{
+    "ok": false,
+    "issues": {
+      "vulnerabilities": [
+      ],
+      "licenses": [
+      ]
+    },
+    "dependencyCount": 57,
+    "packageManager": "poetry"
+  }

--- a/test/fixtures/apiResponsesForProjects/list-all-projects-org-platform.json
+++ b/test/fixtures/apiResponsesForProjects/list-all-projects-org-platform.json
@@ -1,0 +1,36 @@
+{
+    "org": {
+      "name": "Platform",
+      "id": "f6999a85-c519-4ee7-ae55-3269b9bfa4b6"
+    },
+    "projects": [
+      {
+        "name": "poetry.lock",
+        "id": "f51c925b-2abe-4c07-8a0d-21b834aa3074",
+        "created": "2020-03-20T15:26:50.830Z",
+        "origin": "cli",
+        "type": "poetry",
+        "readOnly": false,
+        "testFrequency": "daily",
+        "totalDependencies": 8,
+        "issueCountsBySeverity": {
+          "low": 0,
+          "high": 0,
+          "medium": 0
+        },
+        "remoteRepoUrl": "http://github.com/snyk-tech-services/jira-tickets-for-new-vulns.git",
+        "imageTag": "0.0.0",
+        "lastTestedDate": "2020-07-08T00:11:24.801Z",
+        "browseUrl": "https://app.snyk.io/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074",
+        "owner": null,
+        "importingUser": {
+          "id": "123",
+          "name": "CircleCI pipelines",
+          "username": "CircleCI pipelines",
+          "email": null
+        },
+        "tags": [],
+        "branch": null
+      }
+    ]
+  }

--- a/test/fixtures/dependencies/poetry.json
+++ b/test/fixtures/dependencies/poetry.json
@@ -1,0 +1,662 @@
+{
+    "name": "poetryproject",
+    "version": "1.2.6",
+    "dependencies": {
+      "coverage": {
+        "name": "coverage",
+        "version": "4.5.2"
+      },
+      "django": {
+        "name": "django",
+        "version": "2.2.16",
+        "dependencies": {
+          "pytz": {
+            "name": "pytz",
+            "version": "2019.1"
+          },
+          "sqlparse": {
+            "name": "sqlparse",
+            "version": "0.3.0"
+          }
+        }
+      },
+      "django-cors-headers": {
+        "name": "django-cors-headers",
+        "version": "2.4.0"
+      },
+      "django-environ": {
+        "name": "django-environ",
+        "version": "0.4.5"
+      },
+      "django-filter": {
+        "name": "django-filter",
+        "version": "2.0.0",
+        "dependencies": {
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          }
+        }
+      },
+      "djangorestframework": {
+        "name": "djangorestframework",
+        "version": "3.9.4"
+      },
+      "psycopg2cffi": {
+        "name": "psycopg2cffi",
+        "version": "2.8.1",
+        "dependencies": {
+          "cffi": {
+            "name": "cffi",
+            "version": "1.14.5",
+            "dependencies": {
+              "pycparser": {
+                "name": "pycparser",
+                "version": "2.19"
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "pyyaml": {
+        "name": "pyyaml",
+        "version": "5.4"
+      },
+      "redis": {
+        "name": "redis",
+        "version": "3.0.1"
+      },
+      "requests": {
+        "name": "requests",
+        "version": "2.20.1",
+        "dependencies": {
+          "certifi": {
+            "name": "certifi",
+            "version": "2019.6.16"
+          },
+          "chardet": {
+            "name": "chardet",
+            "version": "3.0.4"
+          },
+          "idna": {
+            "name": "idna",
+            "version": "2.7"
+          },
+          "urllib3": {
+            "name": "urllib3",
+            "version": "1.24.3"
+          }
+        }
+      },
+      "social-auth-app-django": {
+        "name": "social-auth-app-django",
+        "version": "4.0.0",
+        "dependencies": {
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          },
+          "social-auth-core": {
+            "name": "social-auth-core",
+            "version": "3.3.3",
+            "dependencies": {
+              "cryptography": {
+                "name": "cryptography",
+                "version": "3.3.2",
+                "dependencies": {
+                  "cffi": {
+                    "name": "cffi",
+                    "version": "1.14.5",
+                    "dependencies": {
+                      "pycparser": {
+                        "name": "pycparser",
+                        "version": "2.19"
+                      }
+                    }
+                  },
+                  "six": {
+                    "name": "six",
+                    "version": "1.12.0"
+                  }
+                }
+              },
+              "defusedxml": {
+                "name": "defusedxml",
+                "version": "0.7.0rc1"
+              },
+              "oauthlib": {
+                "name": "oauthlib",
+                "version": "3.0.2"
+              },
+              "pyjwt": {
+                "name": "pyjwt",
+                "version": "1.7.1"
+              },
+              "python3-openid": {
+                "name": "python3-openid",
+                "version": "3.1.0",
+                "dependencies": {
+                  "defusedxml": {
+                    "name": "defusedxml",
+                    "version": "0.7.0rc1"
+                  }
+                }
+              },
+              "requests": {
+                "name": "requests",
+                "version": "2.20.1",
+                "dependencies": {
+                  "certifi": {
+                    "name": "certifi",
+                    "version": "2019.6.16"
+                  },
+                  "chardet": {
+                    "name": "chardet",
+                    "version": "3.0.4"
+                  },
+                  "idna": {
+                    "name": "idna",
+                    "version": "2.7"
+                  },
+                  "urllib3": {
+                    "name": "urllib3",
+                    "version": "1.24.3"
+                  }
+                }
+              },
+              "requests-oauthlib": {
+                "name": "requests-oauthlib",
+                "version": "1.2.0",
+                "dependencies": {
+                  "oauthlib": {
+                    "name": "oauthlib",
+                    "version": "3.0.2"
+                  },
+                  "requests": {
+                    "name": "requests",
+                    "version": "2.20.1",
+                    "dependencies": {
+                      "certifi": {
+                        "name": "certifi",
+                        "version": "2019.6.16"
+                      },
+                      "chardet": {
+                        "name": "chardet",
+                        "version": "3.0.4"
+                      },
+                      "idna": {
+                        "name": "idna",
+                        "version": "2.7"
+                      },
+                      "urllib3": {
+                        "name": "urllib3",
+                        "version": "1.24.3"
+                      }
+                    }
+                  }
+                }
+              },
+              "six": {
+                "name": "six",
+                "version": "1.12.0"
+              }
+            }
+          }
+        }
+      },
+      "pyngboard": {
+        "name": "pyngboard",
+        "version": "0.0.6",
+        "dependencies": {
+          "requests": {
+            "name": "requests",
+            "version": "2.20.1",
+            "dependencies": {
+              "certifi": {
+                "name": "certifi",
+                "version": "2019.6.16"
+              },
+              "chardet": {
+                "name": "chardet",
+                "version": "3.0.4"
+              },
+              "idna": {
+                "name": "idna",
+                "version": "2.7"
+              },
+              "urllib3": {
+                "name": "urllib3",
+                "version": "1.24.3"
+              }
+            }
+          },
+          "requests-oauthlib": {
+            "name": "requests-oauthlib",
+            "version": "1.2.0",
+            "dependencies": {
+              "oauthlib": {
+                "name": "oauthlib",
+                "version": "3.0.2"
+              },
+              "requests": {
+                "name": "requests",
+                "version": "2.20.1",
+                "dependencies": {
+                  "certifi": {
+                    "name": "certifi",
+                    "version": "2019.6.16"
+                  },
+                  "chardet": {
+                    "name": "chardet",
+                    "version": "3.0.4"
+                  },
+                  "idna": {
+                    "name": "idna",
+                    "version": "2.7"
+                  },
+                  "urllib3": {
+                    "name": "urllib3",
+                    "version": "1.24.3"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "django-extensions": {
+        "name": "django-extensions",
+        "version": "2.1.6",
+        "dependencies": {
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "uwsgi": {
+        "name": "uwsgi",
+        "version": "2.0.18"
+      },
+      "stringcase": {
+        "name": "stringcase",
+        "version": "1.2.0"
+      },
+      "werkzeug": {
+        "name": "werkzeug",
+        "version": "0.15.2"
+      },
+      "django-bootstrap4": {
+        "name": "django-bootstrap4",
+        "version": "0.0.8"
+      },
+      "django-import-export": {
+        "name": "django-import-export",
+        "version": "1.2.0",
+        "dependencies": {
+          "diff-match-patch": {
+            "name": "diff-match-patch",
+            "version": "20181111"
+          },
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          },
+          "tablib": {
+            "name": "tablib",
+            "version": "0.13.0",
+            "dependencies": {
+              "backports.csv": {
+                "name": "backports.csv",
+                "version": "1.0.7"
+              },
+              "odfpy": {
+                "name": "odfpy",
+                "version": "1.4.0",
+                "dependencies": {
+                  "defusedxml": {
+                    "name": "defusedxml",
+                    "version": "0.7.0rc1"
+                  }
+                }
+              },
+              "openpyxl": {
+                "name": "openpyxl",
+                "version": "2.6.2",
+                "dependencies": {
+                  "et-xmlfile": {
+                    "name": "et-xmlfile",
+                    "version": "1.0.1"
+                  },
+                  "jdcal": {
+                    "name": "jdcal",
+                    "version": "1.4.1"
+                  }
+                }
+              },
+              "pyyaml": {
+                "name": "pyyaml",
+                "version": "5.4"
+              },
+              "xlrd": {
+                "name": "xlrd",
+                "version": "1.2.0"
+              },
+              "xlwt": {
+                "name": "xlwt",
+                "version": "1.3.0"
+              }
+            }
+          }
+        }
+      },
+      "sentry-sdk": {
+        "name": "sentry-sdk",
+        "version": "0.7.14",
+        "dependencies": {
+          "certifi": {
+            "name": "certifi",
+            "version": "2019.6.16"
+          },
+          "urllib3": {
+            "name": "urllib3",
+            "version": "1.24.3"
+          }
+        }
+      },
+      "django-health-check": {
+        "name": "django-health-check",
+        "version": "3.11.1",
+        "dependencies": {
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          }
+        }
+      },
+      "retry": {
+        "name": "retry",
+        "version": "0.9.2",
+        "dependencies": {
+          "decorator": {
+            "name": "decorator",
+            "version": "4.4.0"
+          },
+          "py": {
+            "name": "py",
+            "version": "1.8.0"
+          }
+        }
+      },
+      "django-oauth-toolkit": {
+        "name": "django-oauth-toolkit",
+        "version": "1.3.2",
+        "dependencies": {
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          },
+          "oauthlib": {
+            "name": "oauthlib",
+            "version": "3.0.2"
+          },
+          "requests": {
+            "name": "requests",
+            "version": "2.20.1",
+            "dependencies": {
+              "certifi": {
+                "name": "certifi",
+                "version": "2019.6.16"
+              },
+              "chardet": {
+                "name": "chardet",
+                "version": "3.0.4"
+              },
+              "idna": {
+                "name": "idna",
+                "version": "2.7"
+              },
+              "urllib3": {
+                "name": "urllib3",
+                "version": "1.24.3"
+              }
+            }
+          }
+        }
+      },
+      "python-jose": {
+        "name": "python-jose",
+        "version": "3.2.0",
+        "dependencies": {
+          "ecdsa": {
+            "name": "ecdsa",
+            "version": "0.14.1",
+            "dependencies": {
+              "six": {
+                "name": "six",
+                "version": "1.12.0"
+              }
+            }
+          },
+          "pyasn1": {
+            "name": "pyasn1",
+            "version": "0.4.8"
+          },
+          "rsa": {
+            "name": "rsa",
+            "version": "4.6",
+            "dependencies": {
+              "pyasn1": {
+                "name": "pyasn1",
+                "version": "0.4.8"
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "social-auth-core": {
+        "name": "social-auth-core",
+        "version": "3.3.3",
+        "dependencies": {
+          "cryptography": {
+            "name": "cryptography",
+            "version": "3.3.2",
+            "dependencies": {
+              "cffi": {
+                "name": "cffi",
+                "version": "1.14.5",
+                "dependencies": {
+                  "pycparser": {
+                    "name": "pycparser",
+                    "version": "2.19"
+                  }
+                }
+              },
+              "six": {
+                "name": "six",
+                "version": "1.12.0"
+              }
+            }
+          },
+          "defusedxml": {
+            "name": "defusedxml",
+            "version": "0.7.0rc1"
+          },
+          "oauthlib": {
+            "name": "oauthlib",
+            "version": "3.0.2"
+          },
+          "pyjwt": {
+            "name": "pyjwt",
+            "version": "1.7.1"
+          },
+          "python3-openid": {
+            "name": "python3-openid",
+            "version": "3.1.0",
+            "dependencies": {
+              "defusedxml": {
+                "name": "defusedxml",
+                "version": "0.7.0rc1"
+              }
+            }
+          },
+          "requests": {
+            "name": "requests",
+            "version": "2.20.1",
+            "dependencies": {
+              "certifi": {
+                "name": "certifi",
+                "version": "2019.6.16"
+              },
+              "chardet": {
+                "name": "chardet",
+                "version": "3.0.4"
+              },
+              "idna": {
+                "name": "idna",
+                "version": "2.7"
+              },
+              "urllib3": {
+                "name": "urllib3",
+                "version": "1.24.3"
+              }
+            }
+          },
+          "requests-oauthlib": {
+            "name": "requests-oauthlib",
+            "version": "1.2.0",
+            "dependencies": {
+              "oauthlib": {
+                "name": "oauthlib",
+                "version": "3.0.2"
+              },
+              "requests": {
+                "name": "requests",
+                "version": "2.20.1",
+                "dependencies": {
+                  "certifi": {
+                    "name": "certifi",
+                    "version": "2019.6.16"
+                  },
+                  "chardet": {
+                    "name": "chardet",
+                    "version": "3.0.4"
+                  },
+                  "idna": {
+                    "name": "idna",
+                    "version": "2.7"
+                  },
+                  "urllib3": {
+                    "name": "urllib3",
+                    "version": "1.24.3"
+                  }
+                }
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "core-logging": {
+        "name": "core-logging",
+        "version": "2.2.0",
+        "dependencies": {
+          "django-ipware": {
+            "name": "django-ipware",
+            "version": "2.1.0"
+          },
+          "json-log-formatter": {
+            "name": "json-log-formatter",
+            "version": "0.2.0"
+          }
+        }
+      },
+      "slack-sdk": {
+        "name": "slack-sdk",
+        "version": "3.1.0"
+      },
+      "cffi": {
+        "name": "cffi",
+        "version": "1.14.5",
+        "dependencies": {
+          "pycparser": {
+            "name": "pycparser",
+            "version": "2.19"
+          }
+        }
+      },
+      "cryptography": {
+        "name": "cryptography",
+        "version": "3.3.2",
+        "dependencies": {
+          "cffi": {
+            "name": "cffi",
+            "version": "1.14.5",
+            "dependencies": {
+              "pycparser": {
+                "name": "pycparser",
+                "version": "2.19"
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      }
+    },
+    "type": "poetry",
+    "packageFormatVersion": "poetry:0.0.1"
+  }

--- a/test/fixtures/snykTestsOutputs/poetry.json
+++ b/test/fixtures/snykTestsOutputs/poetry.json
@@ -1,0 +1,690 @@
+{
+    "name": "poetry",
+    "version": "1.2.6",
+    "dependencies": {
+      "coverage": {
+        "name": "coverage",
+        "version": "4.5.2"
+      },
+      "django": {
+        "name": "django",
+        "version": "2.2.16",
+        "dependencies": {
+          "pytz": {
+            "name": "pytz",
+            "version": "2019.1"
+          },
+          "sqlparse": {
+            "name": "sqlparse",
+            "version": "0.3.0"
+          }
+        }
+      },
+      "django-cors-headers": {
+        "name": "django-cors-headers",
+        "version": "2.4.0"
+      },
+      "django-environ": {
+        "name": "django-environ",
+        "version": "0.4.5"
+      },
+      "django-filter": {
+        "name": "django-filter",
+        "version": "2.0.0",
+        "dependencies": {
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          }
+        }
+      },
+      "djangorestframework": {
+        "name": "djangorestframework",
+        "version": "3.9.4"
+      },
+      "psycopg2cffi": {
+        "name": "psycopg2cffi",
+        "version": "2.8.1",
+        "dependencies": {
+          "cffi": {
+            "name": "cffi",
+            "version": "1.14.5",
+            "dependencies": {
+              "pycparser": {
+                "name": "pycparser",
+                "version": "2.19"
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "pyyaml": {
+        "name": "pyyaml",
+        "version": "5.4"
+      },
+      "redis": {
+        "name": "redis",
+        "version": "3.0.1"
+      },
+      "requests": {
+        "name": "requests",
+        "version": "2.20.1",
+        "dependencies": {
+          "certifi": {
+            "name": "certifi",
+            "version": "2019.6.16"
+          },
+          "chardet": {
+            "name": "chardet",
+            "version": "3.0.4"
+          },
+          "idna": {
+            "name": "idna",
+            "version": "2.7"
+          },
+          "urllib3": {
+            "name": "urllib3",
+            "version": "1.24.3"
+          }
+        }
+      },
+      "social-auth-app-django": {
+        "name": "social-auth-app-django",
+        "version": "4.0.0",
+        "dependencies": {
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          },
+          "social-auth-core": {
+            "name": "social-auth-core",
+            "version": "3.3.3",
+            "dependencies": {
+              "cryptography": {
+                "name": "cryptography",
+                "version": "3.3.2",
+                "dependencies": {
+                  "cffi": {
+                    "name": "cffi",
+                    "version": "1.14.5",
+                    "dependencies": {
+                      "pycparser": {
+                        "name": "pycparser",
+                        "version": "2.19"
+                      }
+                    }
+                  },
+                  "six": {
+                    "name": "six",
+                    "version": "1.12.0"
+                  }
+                }
+              },
+              "defusedxml": {
+                "name": "defusedxml",
+                "version": "0.7.0rc1"
+              },
+              "oauthlib": {
+                "name": "oauthlib",
+                "version": "3.0.2"
+              },
+              "pyjwt": {
+                "name": "pyjwt",
+                "version": "1.7.1"
+              },
+              "python3-openid": {
+                "name": "python3-openid",
+                "version": "3.1.0",
+                "dependencies": {
+                  "defusedxml": {
+                    "name": "defusedxml",
+                    "version": "0.7.0rc1"
+                  }
+                }
+              },
+              "requests": {
+                "name": "requests",
+                "version": "2.20.1",
+                "dependencies": {
+                  "certifi": {
+                    "name": "certifi",
+                    "version": "2019.6.16"
+                  },
+                  "chardet": {
+                    "name": "chardet",
+                    "version": "3.0.4"
+                  },
+                  "idna": {
+                    "name": "idna",
+                    "version": "2.7"
+                  },
+                  "urllib3": {
+                    "name": "urllib3",
+                    "version": "1.24.3"
+                  }
+                }
+              },
+              "requests-oauthlib": {
+                "name": "requests-oauthlib",
+                "version": "1.2.0",
+                "dependencies": {
+                  "oauthlib": {
+                    "name": "oauthlib",
+                    "version": "3.0.2"
+                  },
+                  "requests": {
+                    "name": "requests",
+                    "version": "2.20.1",
+                    "dependencies": {
+                      "certifi": {
+                        "name": "certifi",
+                        "version": "2019.6.16"
+                      },
+                      "chardet": {
+                        "name": "chardet",
+                        "version": "3.0.4"
+                      },
+                      "idna": {
+                        "name": "idna",
+                        "version": "2.7"
+                      },
+                      "urllib3": {
+                        "name": "urllib3",
+                        "version": "1.24.3"
+                      }
+                    }
+                  }
+                }
+              },
+              "six": {
+                "name": "six",
+                "version": "1.12.0"
+              }
+            }
+          }
+        }
+      },
+      "pyngboard": {
+        "name": "pyngboard",
+        "version": "0.0.6",
+        "dependencies": {
+          "requests": {
+            "name": "requests",
+            "version": "2.20.1",
+            "dependencies": {
+              "certifi": {
+                "name": "certifi",
+                "version": "2019.6.16"
+              },
+              "chardet": {
+                "name": "chardet",
+                "version": "3.0.4"
+              },
+              "idna": {
+                "name": "idna",
+                "version": "2.7"
+              },
+              "urllib3": {
+                "name": "urllib3",
+                "version": "1.24.3"
+              }
+            }
+          },
+          "requests-oauthlib": {
+            "name": "requests-oauthlib",
+            "version": "1.2.0",
+            "dependencies": {
+              "oauthlib": {
+                "name": "oauthlib",
+                "version": "3.0.2"
+              },
+              "requests": {
+                "name": "requests",
+                "version": "2.20.1",
+                "dependencies": {
+                  "certifi": {
+                    "name": "certifi",
+                    "version": "2019.6.16"
+                  },
+                  "chardet": {
+                    "name": "chardet",
+                    "version": "3.0.4"
+                  },
+                  "idna": {
+                    "name": "idna",
+                    "version": "2.7"
+                  },
+                  "urllib3": {
+                    "name": "urllib3",
+                    "version": "1.24.3"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "django-extensions": {
+        "name": "django-extensions",
+        "version": "2.1.6",
+        "dependencies": {
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "uwsgi": {
+        "name": "uwsgi",
+        "version": "2.0.18"
+      },
+      "stringcase": {
+        "name": "stringcase",
+        "version": "1.2.0"
+      },
+      "werkzeug": {
+        "name": "werkzeug",
+        "version": "0.15.2"
+      },
+      "django-bootstrap4": {
+        "name": "django-bootstrap4",
+        "version": "0.0.8"
+      },
+      "django-import-export": {
+        "name": "django-import-export",
+        "version": "1.2.0",
+        "dependencies": {
+          "diff-match-patch": {
+            "name": "diff-match-patch",
+            "version": "20181111"
+          },
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          },
+          "tablib": {
+            "name": "tablib",
+            "version": "0.13.0",
+            "dependencies": {
+              "backports.csv": {
+                "name": "backports.csv",
+                "version": "1.0.7"
+              },
+              "odfpy": {
+                "name": "odfpy",
+                "version": "1.4.0",
+                "dependencies": {
+                  "defusedxml": {
+                    "name": "defusedxml",
+                    "version": "0.7.0rc1"
+                  }
+                }
+              },
+              "openpyxl": {
+                "name": "openpyxl",
+                "version": "2.6.2",
+                "dependencies": {
+                  "et-xmlfile": {
+                    "name": "et-xmlfile",
+                    "version": "1.0.1"
+                  },
+                  "jdcal": {
+                    "name": "jdcal",
+                    "version": "1.4.1"
+                  }
+                }
+              },
+              "pyyaml": {
+                "name": "pyyaml",
+                "version": "5.4"
+              },
+              "xlrd": {
+                "name": "xlrd",
+                "version": "1.2.0"
+              },
+              "xlwt": {
+                "name": "xlwt",
+                "version": "1.3.0"
+              }
+            }
+          }
+        }
+      },
+      "sentry-sdk": {
+        "name": "sentry-sdk",
+        "version": "0.7.14",
+        "dependencies": {
+          "certifi": {
+            "name": "certifi",
+            "version": "2019.6.16"
+          },
+          "urllib3": {
+            "name": "urllib3",
+            "version": "1.24.3"
+          }
+        }
+      },
+      "django-health-check": {
+        "name": "django-health-check",
+        "version": "3.11.1",
+        "dependencies": {
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          }
+        }
+      },
+      "retry": {
+        "name": "retry",
+        "version": "0.9.2",
+        "dependencies": {
+          "decorator": {
+            "name": "decorator",
+            "version": "4.4.0"
+          },
+          "py": {
+            "name": "py",
+            "version": "1.8.0"
+          }
+        }
+      },
+      "django-oauth-toolkit": {
+        "name": "django-oauth-toolkit",
+        "version": "1.3.2",
+        "dependencies": {
+          "django": {
+            "name": "django",
+            "version": "2.2.16",
+            "dependencies": {
+              "pytz": {
+                "name": "pytz",
+                "version": "2019.1"
+              },
+              "sqlparse": {
+                "name": "sqlparse",
+                "version": "0.3.0"
+              }
+            }
+          },
+          "oauthlib": {
+            "name": "oauthlib",
+            "version": "3.0.2"
+          },
+          "requests": {
+            "name": "requests",
+            "version": "2.20.1",
+            "dependencies": {
+              "certifi": {
+                "name": "certifi",
+                "version": "2019.6.16"
+              },
+              "chardet": {
+                "name": "chardet",
+                "version": "3.0.4"
+              },
+              "idna": {
+                "name": "idna",
+                "version": "2.7"
+              },
+              "urllib3": {
+                "name": "urllib3",
+                "version": "1.24.3"
+              }
+            }
+          }
+        }
+      },
+      "python-jose": {
+        "name": "python-jose",
+        "version": "3.2.0",
+        "dependencies": {
+          "ecdsa": {
+            "name": "ecdsa",
+            "version": "0.14.1",
+            "dependencies": {
+              "six": {
+                "name": "six",
+                "version": "1.12.0"
+              }
+            }
+          },
+          "pyasn1": {
+            "name": "pyasn1",
+            "version": "0.4.8"
+          },
+          "rsa": {
+            "name": "rsa",
+            "version": "4.6",
+            "dependencies": {
+              "pyasn1": {
+                "name": "pyasn1",
+                "version": "0.4.8"
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "social-auth-core": {
+        "name": "social-auth-core",
+        "version": "3.3.3",
+        "dependencies": {
+          "cryptography": {
+            "name": "cryptography",
+            "version": "3.3.2",
+            "dependencies": {
+              "cffi": {
+                "name": "cffi",
+                "version": "1.14.5",
+                "dependencies": {
+                  "pycparser": {
+                    "name": "pycparser",
+                    "version": "2.19"
+                  }
+                }
+              },
+              "six": {
+                "name": "six",
+                "version": "1.12.0"
+              }
+            }
+          },
+          "defusedxml": {
+            "name": "defusedxml",
+            "version": "0.7.0rc1"
+          },
+          "oauthlib": {
+            "name": "oauthlib",
+            "version": "3.0.2"
+          },
+          "pyjwt": {
+            "name": "pyjwt",
+            "version": "1.7.1"
+          },
+          "python3-openid": {
+            "name": "python3-openid",
+            "version": "3.1.0",
+            "dependencies": {
+              "defusedxml": {
+                "name": "defusedxml",
+                "version": "0.7.0rc1"
+              }
+            }
+          },
+          "requests": {
+            "name": "requests",
+            "version": "2.20.1",
+            "dependencies": {
+              "certifi": {
+                "name": "certifi",
+                "version": "2019.6.16"
+              },
+              "chardet": {
+                "name": "chardet",
+                "version": "3.0.4"
+              },
+              "idna": {
+                "name": "idna",
+                "version": "2.7"
+              },
+              "urllib3": {
+                "name": "urllib3",
+                "version": "1.24.3"
+              }
+            }
+          },
+          "requests-oauthlib": {
+            "name": "requests-oauthlib",
+            "version": "1.2.0",
+            "dependencies": {
+              "oauthlib": {
+                "name": "oauthlib",
+                "version": "3.0.2"
+              },
+              "requests": {
+                "name": "requests",
+                "version": "2.20.1",
+                "dependencies": {
+                  "certifi": {
+                    "name": "certifi",
+                    "version": "2019.6.16"
+                  },
+                  "chardet": {
+                    "name": "chardet",
+                    "version": "3.0.4"
+                  },
+                  "idna": {
+                    "name": "idna",
+                    "version": "2.7"
+                  },
+                  "urllib3": {
+                    "name": "urllib3",
+                    "version": "1.24.3"
+                  }
+                }
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      },
+      "core-logging": {
+        "name": "core-logging",
+        "version": "2.2.0",
+        "dependencies": {
+          "django-ipware": {
+            "name": "django-ipware",
+            "version": "2.1.0"
+          },
+          "json-log-formatter": {
+            "name": "json-log-formatter",
+            "version": "0.2.0"
+          }
+        }
+      },
+      "slack-sdk": {
+        "name": "slack-sdk",
+        "version": "3.1.0"
+      },
+      "cffi": {
+        "name": "cffi",
+        "version": "1.14.5",
+        "dependencies": {
+          "pycparser": {
+            "name": "pycparser",
+            "version": "2.19"
+          }
+        }
+      },
+      "cryptography": {
+        "name": "cryptography",
+        "version": "3.3.2",
+        "dependencies": {
+          "cffi": {
+            "name": "cffi",
+            "version": "1.14.5",
+            "dependencies": {
+              "pycparser": {
+                "name": "pycparser",
+                "version": "2.19"
+              }
+            }
+          },
+          "six": {
+            "name": "six",
+            "version": "1.12.0"
+          }
+        }
+      }
+    },
+    "type": "poetry",
+    "packageFormatVersion": "poetry:0.0.1"
+}
+{
+"vulnerabilities": [
+  
+],
+"ok": false,
+"dependencyCount": 57,
+"org": "platform-sgr",
+"policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+"isPrivate": true,
+"licensesPolicy": {
+    "severities": {},
+    "orgLicenseRules": {}
+},
+"packageManager": "poetry",
+"ignoreSettings": null,
+"summary": "19 high or critical severity vulnerable dependency paths",
+"severityThreshold": "high",
+"filesystemPolicy": false,
+"filtered": {
+    "ignore": [],
+    "patch": []
+},
+"uniqueCount": 5,
+"targetFile": "pyproject.toml",
+"projectName": "poetry",
+"displayTargetFile": "pyproject.toml",
+"path": "/Users/snykuser/poetry"
+}

--- a/test/lib/index-inline-with-proj-coord-dep-changes.test.ts
+++ b/test/lib/index-inline-with-proj-coord-dep-changes.test.ts
@@ -98,12 +98,10 @@ describe('Test End 2 End - Inline mode with project coordinates', () => {
       'No new issues found !',
     ];
 
-    //expect(consoleOutput).toContain('No new iss4ues found !');
     expectedOutput.forEach((line: string) => {
       expect(consoleOutput.join()).toContain(line);
     });
     // => When testing, loaded as module therefore returning code === process.exitCode
     expect(mockExit).toHaveBeenCalledWith(0);
-    //expect(result).toEqual(0);
   });
 });

--- a/test/lib/index-inline-with-proj-coord-dep-changes.test.ts
+++ b/test/lib/index-inline-with-proj-coord-dep-changes.test.ts
@@ -1,0 +1,109 @@
+import { stdin, MockSTDIN } from 'mock-stdin';
+import { mockProcessExit } from 'jest-mock-process';
+import * as nock from 'nock';
+import * as path from 'path';
+import * as fs from 'fs';
+//process.argv.push('-d');
+process.argv.push('--baselineOrg=f6999a85-c519-4ee7-ae55-3269b9bfa4b6');
+process.argv.push('--baselineProject=f51c925b-2abe-4c07-8a0d-21b834aa3074');
+
+const stdinMock: MockSTDIN = stdin();
+const mockExit = mockProcessExit();
+import { getDelta } from '../../src/lib/index';
+
+const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
+
+const originalLog = console.log;
+let consoleOutput: Array<string> = [];
+const mockedLog = (output: string): void => {
+  consoleOutput.push(output);
+};
+beforeAll(() => {
+  console.log = mockedLog;
+});
+afterEach(() => {
+  stdinMock.reset();
+});
+
+beforeEach(() => {
+  consoleOutput = [];
+});
+afterAll(() => {
+  setTimeout(() => {
+    console.log = originalLog;
+  }, 500);
+});
+beforeEach(() => {
+  return nock('https://snyk.io')
+    .persist()
+    .post(/.*/)
+    .reply(200, (uri) => {
+      switch (uri) {
+        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/test-poetry.json',
+          );
+        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/projects':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponsesForProjects/list-all-projects-platform.json',
+          );
+        default:
+      }
+    })
+    .get(/.*/)
+    .reply(200, (uri) => {
+      switch (uri) {
+        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/test-poetry.json',
+          );
+        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/dep-graph':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/poetry-depgraph.json',
+          );
+        default:
+      }
+    });
+});
+describe('Test End 2 End - Inline mode with project coordinates', () => {
+  it('Test Inline mode with specified project coordinates - no new issue', async () => {
+    setTimeout(() => {
+      stdinMock.send(
+        fs
+          .readFileSync(fixturesFolderPath + 'snykTestsOutputs/poetry.json')
+          .toString(),
+      );
+      stdinMock.send(null);
+    }, 100);
+
+    const result = await getDelta();
+
+    const expectedOutput = [
+      'Direct deps:',
+      'Added 1',
+      'coverage@4.5.2',
+      'Removed 1',
+      'cffi@1.14.5',
+      'Indirect deps:',
+      'Added 1',
+      'cffi@1.14.5',
+      'Paths',
+      'cffi@1.14.5 no issue:',
+      'cryptography@3.3.2=>cffi@1.14.5',
+      'psycopg2cffi@2.8.1=>cffi@1.14.5',
+      'social-auth-core@3.3.3=>cryptography@3.3.2=>cffi@1.14.5',
+      'social-auth-app-django@4.0.0=>social-auth-core@3.3.3=>cryptography@3.3.2=>cffi@1.14.5',
+      'Removed 1',
+      'No new issues found !',
+    ];
+
+    //expect(consoleOutput).toContain('No new iss4ues found !');
+    expectedOutput.forEach((line: string) => {
+      expect(consoleOutput.join()).toContain(line);
+    });
+    // => When testing, loaded as module therefore returning code === process.exitCode
+    expect(mockExit).toHaveBeenCalledWith(0);
+    //expect(result).toEqual(0);
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Looks up the nodeId in the graph nodes list to then extract the pkgId accordingly since NodeId != PkgId.

### Notes for the reviewer

Does not change the behavior of the direct/indirect deps comparison, but collect the pkgId more reliably by getting the PkgId instead of assuming NodeId == PkgId, which doesn't hold true in some cases in graph generated by [this lib](https://github.com/snyk/dep-graph).
