### PR TITLE
fix: add check for paths lengths comparison first

### DIFF
--- a/src/lib/snyk/issues.ts
+++ b/src/lib/snyk/issues.ts
@@ -31,13 +31,16 @@ const getNewIssues = (
   let newIssues = snykTestJsonIssuesResults;
   MonitoredIssues.forEach((monitoredIssue) => {
     newIssues = _.reject(newIssues, (issue) => {
+      if(!issue.from || !monitoredIssue.from) {
+        debug(`Error: Issue ${issue.id} does not have a vuln path in one of the snapshots`)
+      }
       let issueFromArray = issue.from;
       let upgradePathArray = issue.upgradePath
       if (mode == 'inline') {
         issueFromArray = issueFromArray.slice(1, issueFromArray.length);
         upgradePathArray = upgradePathArray? upgradePathArray.slice(1, issueFromArray.length):undefined;
       }
-
+      
       return (
         monitoredIssue.id == issue.id &&
         !isVulnerablePathNew(monitoredIssue.from, issueFromArray)

--- a/src/lib/utils/issuesUtils.ts
+++ b/src/lib/utils/issuesUtils.ts
@@ -1,9 +1,20 @@
 import * as _ from 'lodash'
+import { getDebugModule } from './utils';
+
+
 
 const isVulnerablePathNew = (monitoredSnapshotPathArray: Array<string>, currentSnapshotPathArray: Array<string> ): boolean => {
-
+    const debug = getDebugModule();
     const versionPatternRegex = /@[a-zA-Z0-9-_\.]+$/
-
+    if(monitoredSnapshotPathArray.length != currentSnapshotPathArray.length){
+        debug('###')
+        debug('Existing path')
+        debug(monitoredSnapshotPathArray)
+        debug('Current path')
+        debug(currentSnapshotPathArray)
+        debug('###')
+        return true
+    }
     return !(_.isEqual(monitoredSnapshotPathArray, currentSnapshotPathArray) || currentSnapshotPathArray.every((path, index) => {
         if(monitoredSnapshotPathArray.length <= 0){
             return false


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Performs an initial check comparing vuln paths to compare path length and avoiding out of bound index in either path during comparison of each item of those paths.
