### PR TITLE
Fix/add passifnobaseline when used as module

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -21,13 +21,12 @@ Snyk Tech Prevent Tool
 `
 
 
-const getDelta = async(snykTestOutput = '', debugMode = false):Promise<SnykDeltaOutput|number> => {
+const getDelta = async(snykTestOutput = '', debugMode = false, setPassIfNoBaselineFlag = false):Promise<SnykDeltaOutput|number> => {
    const argv = utils.init(debugMode)
    const debug = utils.getDebugModule()
    const mode = argv.currentProject || argv.currentOrg ? "standalone" : "inline"
    let newVulns, newLicenseIssues
-   const setPassIfNoBaseline = argv.setPassIfNoBaseline || false
-   let passIfNoBaseline = false
+   const passIfNoBaseline = argv.setPassIfNoBaseline || setPassIfNoBaselineFlag
 
   try {
     if(process.env.NODE_ENV == 'prod'){
@@ -105,9 +104,6 @@ const getDelta = async(snykTestOutput = '', debugMode = false):Promise<SnykDelta
       newVulns = typedSnykTestJsonResults.vulnerabilities.filter(x => x.type != "license")
       newLicenseIssues = typedSnykTestJsonResults.vulnerabilities.filter(x => x.type == "license")
 
-      if (setPassIfNoBaseline) {
-        passIfNoBaseline = true
-      }
       
     } else {
       snykProject = await snyk.getProjectIssues(baselineOrg,baselineProject)

--- a/test/lib/index-inline-no-baseline.test.ts
+++ b/test/lib/index-inline-no-baseline.test.ts
@@ -1,0 +1,108 @@
+import { stdin, MockSTDIN } from 'mock-stdin';
+import { mockProcessExit } from 'jest-mock-process';
+import * as nock from 'nock';
+import * as path from 'path';
+import * as fs from 'fs';
+process.argv.push('--setPassIfNoBaseline true');
+
+const stdinMock: MockSTDIN = stdin();
+const mockExit = mockProcessExit();
+import { getDelta } from '../../src/lib/index';
+
+const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
+
+const originalLog = console.log;
+let consoleOutput: Array<string> = [];
+const mockedLog = (output: string): void => {
+  consoleOutput.push(output);
+};
+beforeAll(() => {
+  console.log = mockedLog;
+});
+afterEach(() => {
+  stdinMock.reset();
+});
+
+beforeEach(() => {
+  consoleOutput = [];
+});
+afterAll(() => {
+  setTimeout(() => {
+    console.log = originalLog;
+  }, 500);
+});
+
+beforeEach(() => {
+  return nock('https://snyk.io')
+    .persist()
+    .post(/.*/)
+    .reply(200, (uri) => {
+      switch (uri) {
+        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/test-goof.json',
+          );
+        case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/test-goof.json',
+          );
+        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/test-gomod.json',
+          );
+        case '/api/v1/org/playground/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/java-goof.json',
+          );
+        case '/api/v1/org/playground/projects':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponsesForProjects/list-all-projects-org-playground.json',
+          );
+        default:
+      }
+    })
+    .get(/.*/)
+    .reply(200, (uri) => {
+      switch (uri) {
+        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/test-goof.json',
+          );
+        default:
+      }
+    });
+});
+
+describe('Test End 2 End - Inline mode - no baseline', () => {
+  it('Test Inline mode - new issues from snyk test', async () => {
+    setTimeout(() => {
+      stdinMock.send(
+        fs
+          .readFileSync(
+            fixturesFolderPath + 'snykTestsOutputs/test-unmonitored-goof.json',
+          )
+          .toString(),
+      );
+      stdinMock.send(null);
+    }, 100);
+
+    const result = await getDelta();
+
+    const expectedOutput = [
+      'New issue introduced !',
+      'Security Vulnerability',
+      '  1/1: Regular Expression Denial of Service (ReDoS) [High Severity]',
+      '    Via: @snyk/nodejs-runtime-agent@1.14.0 => acorn@5.7.3',
+      '    Fixed in: acorn 5.7.4, 6.4.1, 7.1.1',
+      '    Fixable by upgrade:  @snyk/nodejs-runtime-agent@1.14.0=>acorn@5.7.4',
+      'New issue introduced !',
+      'License Issue',
+      '  1/1: GPL-2.0 license [Medium Severity]',
+    ];
+    expectedOutput.forEach((line: string) => {
+      expect(consoleOutput.join()).toContain(line);
+    });
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+});

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -3,7 +3,6 @@ import { mockProcessExit } from 'jest-mock-process';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as fs from 'fs';
-process.argv.push('--setPassIfNoBaseline false');
 
 const stdinMock: MockSTDIN = stdin();
 const mockExit = mockProcessExit();

--- a/test/lib/index-module-no-baseline.test.ts
+++ b/test/lib/index-module-no-baseline.test.ts
@@ -3,9 +3,6 @@ import { stdin, MockSTDIN } from 'mock-stdin';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as fs from 'fs';
-process.argv.push('--setPassIfNoBaseline');
-process.argv.push('true');
-process.argv.push('--d');
 
 const stdinMock: MockSTDIN = stdin();
 
@@ -84,6 +81,8 @@ describe('Test End 2 End - Inline mode', () => {
           fixturesFolderPath + 'snykTestsOutputs/test-unmonitored-goof.json',
         )
         .toString(),
+      false,
+      true,
     );
 
     const expectedResult = {

--- a/test/lib/index-module.test.ts
+++ b/test/lib/index-module.test.ts
@@ -1,7 +1,6 @@
 import * as nock from 'nock';
 import * as path from 'path';
 import * as fs from 'fs';
-//process.argv.push('-d');
 import * as debug from 'debug';
 
 import { getDelta } from '../../src/lib/index';

--- a/test/lib/index-standalone-no-baseline.ts
+++ b/test/lib/index-standalone-no-baseline.ts
@@ -7,6 +7,7 @@ process.argv.push('--baselineOrg=playground');
 process.argv.push('--baselineProject=c51c80c2-66a1-442a-91e2-4f55b4256a72');
 process.argv.push('--currentOrg=playground');
 process.argv.push('--currentProject=c51c80c2-66a1-442a-91e2-4f55b4256a73');
+
 const mockExit = mockProcessExit();
 import { getDelta } from '../../src/lib/index';
 
@@ -34,7 +35,7 @@ afterEach(() => {
   nock.cleanAll();
 });
 
-describe('Test End 2 End - Standalone mode', () => {
+describe('Test End 2 End - Standalone mode without baseline', () => {
   it('Test standalone mode - no new issue', async () => {
     nock('https://snyk.io')
       .persist()


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds capability to pass flag to return 0 if no baseline snapshot is found when using snyk-delta as module (like snyk-prevent-gh-commit-status for instance)