### PR TITLE
fix: add nobaseline indicator in module response

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -27,6 +27,7 @@ const getDelta = async(snykTestOutput = '', debugMode = false, setPassIfNoBaseli
    const mode = argv.currentProject || argv.currentOrg ? "standalone" : "inline"
    let newVulns, newLicenseIssues
    const passIfNoBaseline = argv.setPassIfNoBaseline || setPassIfNoBaselineFlag
+   let noBaseline = false
 
   try {
     if(process.env.NODE_ENV == 'prod'){
@@ -104,7 +105,7 @@ const getDelta = async(snykTestOutput = '', debugMode = false, setPassIfNoBaseli
       newVulns = typedSnykTestJsonResults.vulnerabilities.filter(x => x.type != "license")
       newLicenseIssues = typedSnykTestJsonResults.vulnerabilities.filter(x => x.type == "license")
 
-      
+      noBaseline = true      
     } else {
       snykProject = await snyk.getProjectIssues(baselineOrg,baselineProject)
       const baselineVulnerabilitiesIssues = snykProject.issues.vulnerabilities
@@ -148,7 +149,7 @@ const getDelta = async(snykTestOutput = '', debugMode = false, setPassIfNoBaseli
     if(!module.parent || (isJestTesting() && !expect.getState().currentTestName.includes('module'))){
       process.exit(process.exitCode)
     } else {
-      return {result: process.exitCode, newVulns: newVulns,newLicenseIssues: newLicenseIssues, passIfNoBaseline: passIfNoBaseline}
+      return {result: process.exitCode, newVulns: newVulns,newLicenseIssues: newLicenseIssues, passIfNoBaseline: passIfNoBaseline, noBaseline: noBaseline}
     }
   
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -86,5 +86,6 @@ export interface SnykDeltaOutput {
     result: number | undefined,
     newVulns: IssueWithPaths[] | undefined,
     newLicenseIssues: IssueWithPaths[] | undefined
-    passIfNoBaseline: boolean
+    passIfNoBaseline: boolean,
+    noBaseline: boolean
 }

--- a/test/lib/index-module-no-baseline.test.ts
+++ b/test/lib/index-module-no-baseline.test.ts
@@ -252,6 +252,7 @@ describe('Test End 2 End - Inline mode', () => {
         },
       ],
       passIfNoBaseline: true,
+      noBaseline: true,
     };
 
     expect(result).toEqual(expectedResult);

--- a/test/lib/index-module.test.ts
+++ b/test/lib/index-module.test.ts
@@ -70,6 +70,7 @@ describe('Test End 2 End - Module', () => {
       newVulns: [],
       newLicenseIssues: [],
       passIfNoBaseline: false,
+      noBaseline: false,
     };
     expect(result).toEqual(expectedResult);
   });
@@ -87,6 +88,7 @@ describe('Test End 2 End - Module', () => {
       newVulns: [],
       newLicenseIssues: [],
       passIfNoBaseline: false,
+      noBaseline: false,
     };
     expect(result).toEqual(expectedResult);
   });
@@ -172,6 +174,7 @@ describe('Test End 2 End - Module', () => {
       ],
       newLicenseIssues: [],
       passIfNoBaseline: false,
+      noBaseline: false,
     };
 
     expect(result).toEqual(expectedResult);


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds returning noBaseline indicator.

