### PR TITLE
fix: pin api client to still have issues endpoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "is-uuid": "^1.0.2",
     "lodash": "^4.17.15",
     "snyk": "^1.667.0",
-    "snyk-api-ts-client": "^1.7.2",
+    "snyk-api-ts-client": "1.7.2",
     "source-map-support": "^0.5.16",
     "terminal-link": "^2.1.1",
     "tslib": "^1.10.0",


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pins the snyk-api-ts-client to be 1.7.2. Since snyk-delta doesn't have a lock file (since it can be used as library), it downloads the latest version of the snyk-api-ts-client.
snyk-api-ts-client version 1.7.3 was released today. It generates the client programmatically from the snyk api docs. These docs just removed the /issues endpoint for project issues as it has been deprecated. While the endpoint is still functional for the current users for another couple of weeks (by which point snyk-delta will use a different endpoint to maintain its service), the new version of the client is missing what snyk delta expects, causing this issue.

### Notes for the reviewer

Will unpin this with the next snyk-delta version which will remove the dependency on this deprecated endpoint.
