### PR TITLE
fix: make uuid finding tighter with pkgMgr data

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -62,12 +62,13 @@ const getDelta = async(snykTestOutput = '', debugMode = false, setPassIfNoBaseli
 
       baselineOrg = baselineOrg? baselineOrg : snykTestJsonResults.org
       baselineProject = baselineProject? baselineProject : projectNameFromJson
+      const packageManager: string = snykTestJsonResults.packageManager
 
       if(argv.baselineProject && !isUUID.anyNonNil(baselineProject)){
         throw new BadInputError("Project ID must be valid UUID")
       }
       if(!isUUID.anyNonNil(baselineProject)){
-        baselineProject = await snyk.getProjectUUID(baselineOrg,baselineProject)
+        baselineProject = await snyk.getProjectUUID(baselineOrg,baselineProject,'cli',packageManager)
         if(baselineProject == ''){
           console.warn(
             'Snyk API - Could not find a monitored project matching. \

--- a/src/lib/snyk/snyk.ts
+++ b/src/lib/snyk/snyk.ts
@@ -13,6 +13,7 @@ const getProjectUUID = async (
   orgID: string,
   nonUUIDProjectID: string,
   projectType = 'cli',
+  packageManager: string
 ) => {
   const allProjects = await new snykClient.Org({ orgId: orgID }).projects.post(
     {},
@@ -20,7 +21,7 @@ const getProjectUUID = async (
   const allProjectsArray = allProjects.projects as Array<any>;
   const selectedProjectArray: Array<any> = allProjectsArray.filter(
     (project) =>
-      project.name == nonUUIDProjectID && project.origin == projectType,
+      project.name == nonUUIDProjectID && project.origin == projectType && project.type == packageManager
   );
   if (selectedProjectArray.length == 0) {
     return ''

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -84,6 +84,7 @@ describe('Test endpoint functions', () => {
       '689ce7f9-7943-4a71-b704-2ba575f01089',
       'atokeneduser/goof',
       'cli',
+      'npm',
     );
     expect(project).toEqual('6d5813be-7e6d-4ab8-80c2-1e3e2a454545');
   });
@@ -93,6 +94,7 @@ describe('Test endpoint functions', () => {
       '689ce7f9-7943-4a71-b704-2ba575f01089',
       'whatever',
       'cli',
+      'npm',
     );
     expect(project).toEqual('');
   });
@@ -103,6 +105,7 @@ describe('Test endpoint functions', () => {
         '689ce7f9-7943-4a71-b704-2ba575f01089',
         'atokeneduser/clojure',
         'github',
+        'maven',
       );
       expect(project).toThrow();
     } catch (err) {


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This change makes the getProjectUUID more discriminating when looking for project, using the package manager type for selection so project with the same name but different package manager types are distinguished.

