### PR TITLE
fix: limit paths for Java based projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ snyk-delta-linux
 snyk-delta-macos
 snyk-delta-win.exe
 .vscode/
+.dccache

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/snyk-tech-services/snyk-delta",
   "dependencies": {
     "@snyk/configstore": "^3.2.0-rc1",
-    "@snyk/dep-graph": "^1.18.1",
+    "@snyk/dep-graph": "2.3.0",
     "@types/debug": "^4.1.5",
     "@types/is-uuid": "^1.0.0",
     "app-root-path": "^3.0.0",

--- a/src/lib/snyk/dependencies.ts
+++ b/src/lib/snyk/dependencies.ts
@@ -9,7 +9,6 @@ const displayDependenciesChangeDetails = async (
   monitoredProjectDepGraph: any,
   packageManager: string,
   newVulns: IssueWithPaths[],
-  newLicenseIssues: IssueWithPaths[],
 ) => {
   let snykTestGraph: depgraph.DepGraph;
   if (snykDepsJsonResults && snykDepsJsonResults.depGraph) {
@@ -201,9 +200,12 @@ const consolidateIndirectDepsPaths = (
   listOfDeps: Array<any>,
   snykTestGraph: depgraph.DepGraph,
 ): Map<string, string[][]> => {
+  const pkgPathsToRootOptions = ['maven', 'gradle', 'sbt'].includes(
+    snykTestGraph.pkgManager.name,
+  ) ? { limit: 1} : undefined;
   let snykIndirectDepsPaths = new Map<string, Array<Array<string>>>();
   listOfDeps.forEach((indirectDep) => {
-    snykTestGraph.pkgPathsToRoot(indirectDep.info).forEach((individualPath) => {
+    snykTestGraph.pkgPathsToRoot(indirectDep.info, pkgPathsToRootOptions).forEach((individualPath) => {
       // Group all paths for a given indirect dep together in a map
       let individualPathFormatted = individualPath
         .reverse()

--- a/test/lib/snyk/dependencies.test.ts
+++ b/test/lib/snyk/dependencies.test.ts
@@ -75,7 +75,6 @@ describe('Test Snyk Utils make request properly', () => {
       monitoredProjectDepGraph,
       'npm',
       [],
-      [],
     );
     const expectedResult = [
       '_____________________________',
@@ -117,7 +116,6 @@ describe('Test Snyk Utils make request properly', () => {
       monitoredProjectDepGraph,
       'npm',
       [],
-      [],
     );
     const expectedResult = [
       '_____________________________',
@@ -157,7 +155,6 @@ describe('Test Snyk Utils make request properly', () => {
       snykTestJsonDependencies,
       monitoredProjectDepGraph,
       'npm',
-      [],
       [],
     );
     const expectedResult = [
@@ -259,7 +256,6 @@ describe('Test Snyk Utils make request properly', () => {
       monitoredProjectDepGraph,
       'npm',
       newVulns,
-      [],
     );
     const expectedResult = [
       '_____________________________',
@@ -301,7 +297,6 @@ describe('Test Snyk Utils make request properly', () => {
       monitoredProjectDepGraph,
       'npm',
       [],
-      [],
     );
     const expectedResult = [
       '_____________________________',
@@ -342,7 +337,6 @@ describe('Test Snyk Utils make request properly', () => {
       snykTestJsonDependencies,
       monitoredProjectDepGraph,
       'npm',
-      [],
       [],
     );
     const expectedResult = [


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does


Using [this change](https://github.com/snyk/dep-graph/pull/94) in dep-graph lib for Java projects where there is only one effective path. All other paths are in a sense over reporting vulnerable lines. For example in a graph where two top level deps end in log4j-core (vulnerable version), only one of these will actually fix the version of log4j-core, the other line doesn't control anything. Gradle CLI is reporting all these lines and we only prune npm style on the same transitive line and not across the entire graph like we do in Maven (CLI & SCM).
