### PR TITLE
Fix: use undefined for not set baseline Org

### DIFF
--- a/src/lib/error.ts
+++ b/src/lib/error.ts
@@ -34,7 +34,7 @@ const handleError = (error: Error) => {
       debug(error);
       break;
     default:
-      console.log(`Unexpected error: ${error.message}\n${debugModeMessage}`);
+      console.error(`Unexpected error: ${error.message}\n${debugModeMessage}`);
       debug(error);
   }
 };

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -111,7 +111,6 @@ const getDelta = async (
         baselineOrgPublicId = org;
       }
 
-      // if (!baselineOrgPublicId || !isUUID.anyNonNil(baselineOrgPublicId)) {
       if (!baselineOrgPublicId) {
         throw new BadInputError(
           `In 'inline' mode --baselineOrg or 'snyk test' is required.`,

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -50,6 +50,7 @@ const getDelta = async (
   const passIfNoBaseline = argv.setPassIfNoBaseline ?? setPassIfNoBaselineFlag;
   let baselineProjectPublicID: string | undefined = argv.baselineProject;
   let snykTestJsonDependencies, snykTestJsonResults, newVulns, newLicenseIssues;
+  let baselineOrgPublicId: string | undefined = argv.baselineOrg;
 
   try {
     if (argv.baselineProject && !isUUID.anyNonNil(argv.baselineProject)) {
@@ -57,7 +58,6 @@ const getDelta = async (
         '--baselineProject project ID must be valid UUID',
       );
     }
-    let baselineOrg: string = argv.baselineOrg ?? '';
     const currentOrg: string = argv.currentOrg ?? '';
     const currentProject: string = argv.currentProject ?? '';
     const failOnFixableSetting: string | undefined =
@@ -83,7 +83,6 @@ const getDelta = async (
           ']',
       );
 
-      // TODO: Handle --all-projects setups, bail for now
       if (snykTestJsonInput.length > 2) {
         console.error(
           '--all-projects is not supported. See the Github README.md for advice.',
@@ -108,12 +107,22 @@ const getDelta = async (
         ? `${projectName}:${targetFile}`
         : `${projectName}`;
 
-      baselineOrg = baselineOrg ? baselineOrg : org;
+      if (!baselineOrgPublicId) {
+        baselineOrgPublicId = org;
+      }
+
+      // if (!baselineOrgPublicId || !isUUID.anyNonNil(baselineOrgPublicId)) {
+      if (!baselineOrgPublicId) {
+        throw new BadInputError(
+          `In 'inline' mode --baselineOrg or 'snyk test' is required.`,
+        );
+      }
+
       if (!baselineProjectPublicID) {
         baselineProjectPublicID =
           projectId ??
           (await snyk.getProjectUUID(
-            baselineOrg,
+            baselineOrgPublicId,
             projectNameFromJson,
             'cli',
             packageManager,
@@ -133,7 +142,7 @@ const getDelta = async (
       if (
         !argv.currentProject ||
         !argv.currentOrg ||
-        !argv.baselineOrg ||
+        !baselineOrgPublicId ||
         !argv.baselineProject
       ) {
         throw new BadInputError(
@@ -157,16 +166,20 @@ const getDelta = async (
       snykTestJsonResults = projectIssuesFromAPI.issues;
     }
 
-    //TODO: If baseline project is '' and strictMode is false, display current vulns
     debug(
       `Retrieving Snyk Project %s in org %s`,
       baselineProjectPublicID,
-      baselineOrg,
+      baselineOrgPublicId,
     );
     const issueTypeFilter: string = argv.type ? argv.type : 'all';
     let snykProject: IssuesPostResponseType;
     const typedSnykTestJsonResults = snykTestJsonResults as SnykCliTestOutput;
 
+    if (!typedSnykTestJsonResults.vulnerabilities) {
+      throw new BadInputError(
+        "Expected 'snyk test --json' output to contain .vulnerabilities[] property but none was found. Ensure 'snyk test --json' completed successfully.",
+      );
+    }
     // if no baseline, return returned results straight from CLI
     if (!baselineProjectPublicID) {
       newVulns = typedSnykTestJsonResults.vulnerabilities.filter(
@@ -177,7 +190,7 @@ const getDelta = async (
       );
     } else {
       snykProject = await snyk.getProjectIssues(
-        baselineOrg,
+        baselineOrgPublicId,
         baselineProjectPublicID,
       );
 
@@ -209,7 +222,7 @@ const getDelta = async (
 
       if (snykTestJsonDependencies) {
         const monitoredProjectDepGraph = await snyk.getProjectDepGraph(
-          baselineOrg,
+          baselineOrgPublicId,
           baselineProjectPublicID,
         );
         // TODO: Refactor function below

--- a/test/fixtures/snykTestsOutputs/poetry.json
+++ b/test/fixtures/snykTestsOutputs/poetry.json
@@ -661,30 +661,30 @@
     "packageFormatVersion": "poetry:0.0.1"
 }
 {
-"vulnerabilities": [
-  
-],
-"ok": false,
-"dependencyCount": 57,
-"org": "platform-sgr",
-"policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
-"isPrivate": true,
-"licensesPolicy": {
-    "severities": {},
-    "orgLicenseRules": {}
-},
-"packageManager": "poetry",
-"ignoreSettings": null,
-"summary": "19 high or critical severity vulnerable dependency paths",
-"severityThreshold": "high",
-"filesystemPolicy": false,
-"filtered": {
-    "ignore": [],
-    "patch": []
-},
-"uniqueCount": 5,
-"targetFile": "pyproject.toml",
-"projectName": "poetry",
-"displayTargetFile": "pyproject.toml",
-"path": "/Users/snykuser/poetry"
+  "vulnerabilities": [
+
+  ],
+  "ok": false,
+  "dependencyCount": 57,
+  "org": "platform-sgr",
+  "policy": "# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.\nversion: v1.19.0\nignore: {}\npatch: {}\n",
+  "isPrivate": true,
+  "licensesPolicy": {
+      "severities": {},
+      "orgLicenseRules": {}
+  },
+  "packageManager": "poetry",
+  "ignoreSettings": null,
+  "summary": "19 high or critical severity vulnerable dependency paths",
+  "severityThreshold": "high",
+  "filesystemPolicy": false,
+  "filtered": {
+      "ignore": [],
+      "patch": []
+  },
+  "uniqueCount": 5,
+  "targetFile": "pyproject.toml",
+  "projectName": "poetry",
+  "displayTargetFile": "pyproject.toml",
+  "path": "/Users/snykuser/poetry"
 }

--- a/test/lib/index-inline-no-baseline.test.ts
+++ b/test/lib/index-inline-no-baseline.test.ts
@@ -3,78 +3,78 @@ import { mockProcessExit } from 'jest-mock-process';
 import * as nock from 'nock';
 import * as path from 'path';
 import * as fs from 'fs';
-process.argv.push('--setPassIfNoBaseline true');
-
-const stdinMock: MockSTDIN = stdin();
-const mockExit = mockProcessExit();
 import { getDelta } from '../../src/lib/index';
-
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
-const originalLog = console.log;
-let consoleOutput: Array<string> = [];
-const mockedLog = (output: string): void => {
-  consoleOutput.push(output);
-};
-beforeAll(() => {
-  console.log = mockedLog;
-});
-afterEach(() => {
-  stdinMock.reset();
-});
-
-beforeEach(() => {
-  consoleOutput = [];
-});
-afterAll(() => {
-  setTimeout(() => {
-    console.log = originalLog;
-  }, 500);
-});
-
-beforeEach(() => {
-  return nock('https://snyk.io')
-    .persist()
-    .post(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-goof.json',
-          );
-        case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-goof.json',
-          );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-gomod.json',
-          );
-        case '/api/v1/org/playground/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/java-goof.json',
-          );
-        case '/api/v1/org/playground/projects':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponsesForProjects/list-all-projects-org-playground.json',
-          );
-        default:
-      }
-    })
-    .get(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-goof.json',
-          );
-        default:
-      }
-    });
-});
+process.argv.push('--setPassIfNoBaseline true');
 
 describe('Test End 2 End - Inline mode - no baseline', () => {
+  const stdinMock: MockSTDIN = stdin();
+  const mockExit = mockProcessExit();
+  const originalLog = console.log;
+  let consoleOutput: Array<string> = [];
+  const mockedLog = (output: string): void => {
+    consoleOutput.push(output);
+  };
+  beforeAll(() => {
+    console.log = mockedLog;
+  });
+  afterEach(() => {
+    stdinMock.reset();
+  });
+
+  beforeEach(() => {
+    consoleOutput = [];
+  });
+  afterAll(() => {
+    jest.resetAllMocks();
+    setTimeout(() => {
+      console.log = originalLog;
+    }, 500);
+  });
+
+  beforeEach(() => {
+    return nock('https://snyk.io')
+      .persist()
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-gomod.json',
+            );
+          case '/api/v1/org/playground/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/java-goof.json',
+            );
+          case '/api/v1/org/playground/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-playground.json',
+            );
+          default:
+        }
+      })
+      .get(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          default:
+        }
+      });
+  });
+
   it('Test Inline mode - new issues from snyk test', async () => {
     setTimeout(() => {
       stdinMock.send(

--- a/test/lib/index-inline-with-proj-coord-dep-changes.test.ts
+++ b/test/lib/index-inline-with-proj-coord-dep-changes.test.ts
@@ -10,63 +10,63 @@ process.argv.push('--baselineProject=f51c925b-2abe-4c07-8a0d-21b834aa3074');
 const stdinMock: MockSTDIN = stdin();
 const mockExit = mockProcessExit();
 import { getDelta } from '../../src/lib/index';
-
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
-const originalLog = console.log;
-let consoleOutput: Array<string> = [];
-const mockedLog = (output: string): void => {
-  consoleOutput.push(output);
-};
-beforeAll(() => {
-  console.log = mockedLog;
-});
-afterEach(() => {
-  stdinMock.reset();
-});
-
-beforeEach(() => {
-  consoleOutput = [];
-});
-afterAll(() => {
-  setTimeout(() => {
-    console.log = originalLog;
-  }, 500);
-});
-beforeEach(() => {
-  return nock('https://snyk.io')
-    .persist()
-    .post(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-poetry.json',
-          );
-        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/projects':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponsesForProjects/list-all-projects-platform.json',
-          );
-        default:
-      }
-    })
-    .get(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-poetry.json',
-          );
-        case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/poetry-depgraph.json',
-          );
-        default:
-      }
-    });
-});
 describe('Test End 2 End - Inline mode with project coordinates', () => {
+  const originalLog = console.log;
+  let consoleOutput: Array<string> = [];
+  const mockedLog = (output: string): void => {
+    consoleOutput.push(output);
+  };
+  beforeAll(() => {
+    console.log = mockedLog;
+  });
+  afterEach(() => {
+    stdinMock.reset();
+  });
+
+  beforeEach(() => {
+    consoleOutput = [];
+  });
+  afterAll(() => {
+    jest.resetAllMocks();
+    setTimeout(() => {
+      console.log = originalLog;
+    }, 500);
+  });
+  beforeEach(() => {
+    return nock('https://snyk.io')
+      .persist()
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-poetry.json',
+            );
+          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-platform.json',
+            );
+          default:
+        }
+      })
+      .get(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-poetry.json',
+            );
+          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/poetry-depgraph.json',
+            );
+          default:
+        }
+      });
+  });
   it('Test Inline mode with specified project coordinates - no new issue', async () => {
     setTimeout(() => {
       stdinMock.send(

--- a/test/lib/index-inline-with-project-coordinates.test.ts
+++ b/test/lib/index-inline-with-project-coordinates.test.ts
@@ -12,70 +12,70 @@ const mockExit = mockProcessExit();
 import { getDelta } from '../../src/lib/index';
 
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
-
-const originalLog = console.log;
-let consoleOutput: Array<string> = [];
-const mockedLog = (output: string): void => {
-  consoleOutput.push(output);
-};
-beforeAll(() => {
-  console.log = mockedLog;
-});
-afterEach(() => {
-  stdinMock.reset();
-});
-
-beforeEach(() => {
-  consoleOutput = [];
-});
-afterAll(() => {
-  setTimeout(() => {
-    console.log = originalLog;
-  }, 500);
-});
-
-beforeEach(() => {
-  return nock('https://snyk.io')
-    .persist()
-    .post(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/test-goof-aggregated-one-vuln.json',
-          );
-        case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/test-goof-aggregated-one-vuln.json',
-          );
-        case '/api/v1/org/playground/projects':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponsesForProjects/list-all-projects-org-playground.json',
-          );
-        default:
-      }
-    })
-    .get(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
-          );
-        case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
-          );
-        default:
-      }
-    });
-});
-
 describe('Test End 2 End - Inline mode with project coordinates', () => {
+  const originalLog = console.log;
+  let consoleOutput: Array<string> = [];
+  const mockedLog = (output: string): void => {
+    consoleOutput.push(output);
+  };
+  beforeAll(() => {
+    console.log = mockedLog;
+  });
+  afterEach(() => {
+    stdinMock.reset();
+  });
+
+  beforeEach(() => {
+    consoleOutput = [];
+  });
+  afterAll(() => {
+    jest.resetAllMocks();
+    setTimeout(() => {
+      console.log = originalLog;
+    }, 500);
+  });
+
+  beforeEach(() => {
+    return nock('https://snyk.io')
+      .persist()
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/api/v1/org/playground/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-playground.json',
+            );
+          default:
+        }
+      })
+      .get(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
+            );
+          case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          default:
+        }
+      });
+  });
+
   it('Test Inline mode with specified project coordinates - no new issue', async () => {
     setTimeout(() => {
       stdinMock.send(

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -10,193 +10,193 @@ import { getDelta } from '../../src/lib/index';
 
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
-const originalLog = console.log;
-
-let consoleOutput: Array<string> = [];
-const mockedLog = (output: string): void => {
-  consoleOutput.push(output);
-};
-beforeAll(() => {
-  console.log = mockedLog;
-});
-afterEach(() => {
-  stdinMock.reset();
-});
-
-beforeEach(() => {
-  consoleOutput = [];
-});
-afterAll(() => {
-  setTimeout(() => {
-    console.log = originalLog;
-  }, 500);
-});
-
-beforeEach(() => {
-  return nock('https://snyk.io')
-    .persist()
-    .post(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/test-goof-aggregated-one-vuln-one-license.json',
-          );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-gomod-aggregated.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/java-goof-todolist-core-aggregated-issues.json',
-          );
-        case '/api/v1/org/playground/projects':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponsesForProjects/list-all-projects-org-playground.json',
-          );
-        case '/api/v1/org/customerorg/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/projectId-aggregated-issues.json',
-          );
-
-        default:
-      }
-    })
-    .get(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
-          );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/java-goof-todolist-core-depgraph.json',
-          );
-        case '/api/v1/org/customerorg/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath + 'dependencies/projectId-depgraph.json',
-          );
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
-          );
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-1041788/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-1041788.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-584563/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-584563.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461017/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-C3P0-461017.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-174153/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-DOM4J-174153.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461018/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-C3P0-461018.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-31325/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-31325.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:c3p0:c3p0:LGPL-3.0/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-snyk:lic:maven:c3p0:c3p0:LGPL-3.0.json',
-          );
-        case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-2812975/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/vuln-path-SNYK-JAVA-DOM4J-2812975.json',
-          );
-        default:
-      }
-    });
-});
-
 describe('Test End 2 End - Inline mode', () => {
+  const originalLog = console.log;
+
+  let consoleOutput: Array<string> = [];
+  const mockedLog = (output: string): void => {
+    consoleOutput.push(output);
+  };
+  beforeAll(() => {
+    console.log = mockedLog;
+  });
+  afterEach(() => {
+    stdinMock.reset();
+  });
+
+  beforeEach(() => {
+    consoleOutput = [];
+  });
+  afterAll(() => {
+    jest.resetAllMocks();
+    setTimeout(() => {
+      console.log = originalLog;
+    }, 500);
+  });
+
+  beforeEach(() => {
+    return nock('https://snyk.io')
+      .persist()
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln-one-license.json',
+            );
+          case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-gomod-aggregated.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/java-goof-todolist-core-aggregated-issues.json',
+            );
+          case '/api/v1/org/playground/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-playground.json',
+            );
+          case '/api/v1/org/customerorg/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/projectId-aggregated-issues.json',
+            );
+
+          default:
+        }
+      })
+      .get(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/java-goof-todolist-core-depgraph.json',
+            );
+          case '/api/v1/org/customerorg/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'dependencies/projectId-depgraph.json',
+            );
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
+            );
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-1041788/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-1041788.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-584563/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-584563.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461017/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-C3P0-461017.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-174153/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-DOM4J-174153.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461018/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-C3P0-461018.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-31325/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-31325.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:c3p0:c3p0:LGPL-3.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:c3p0:c3p0:LGPL-3.0.json',
+            );
+          case '/api/v1/org/playground/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-2812975/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-DOM4J-2812975.json',
+            );
+          default:
+        }
+      });
+  });
   it('Test Inline mode - no new issue', async () => {
     setTimeout(() => {
       stdinMock.send(

--- a/test/lib/index-module-no-baseline.test.ts
+++ b/test/lib/index-module-no-baseline.test.ts
@@ -10,70 +10,71 @@ import { getDelta } from '../../src/lib/index';
 
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
-const originalLog = console.log;
-let consoleOutput: Array<string> = [];
-const mockedLog = (output: string): void => {
-  consoleOutput.push(output);
-};
-beforeAll(() => {
-  console.log = mockedLog;
-});
-afterEach(() => {
-  stdinMock.reset();
-});
-
-beforeEach(() => {
-  consoleOutput = [];
-});
-afterAll(() => {
-  setTimeout(() => {
-    console.log = originalLog;
-  }, 500);
-});
-
-beforeEach(() => {
-  return nock('https://snyk.io')
-    .persist()
-    .post(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-goof.json',
-          );
-        case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-goof.json',
-          );
-        case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-gomod.json',
-          );
-        case '/api/v1/org/playground/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/java-goof.json',
-          );
-        case '/api/v1/org/playground/projects':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponsesForProjects/list-all-projects-org-playground.json',
-          );
-        default:
-      }
-    })
-    .get(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/test-goof.json',
-          );
-        default:
-      }
-    });
-});
-
 describe('Test End 2 End - Inline mode', () => {
+  const originalLog = console.log;
+  let consoleOutput: Array<string> = [];
+  const mockedLog = (output: string): void => {
+    consoleOutput.push(output);
+  };
+  beforeAll(() => {
+    console.log = mockedLog;
+  });
+  afterEach(() => {
+    stdinMock.reset();
+  });
+
+  beforeEach(() => {
+    consoleOutput = [];
+  });
+  afterAll(() => {
+    jest.resetAllMocks();
+    setTimeout(() => {
+      console.log = originalLog;
+    }, 500);
+  });
+
+  beforeEach(() => {
+    return nock('https://snyk.io')
+      .persist()
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/api/v1/org/playground/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-gomod.json',
+            );
+          case '/api/v1/org/playground/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/java-goof.json',
+            );
+          case '/api/v1/org/playground/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-playground.json',
+            );
+          default:
+        }
+      })
+      .get(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          default:
+        }
+      });
+  });
+
   it('Test module - no monitored project found - return vulns and 0 exit code', async () => {
     const result = await getDelta(
       fs

--- a/test/lib/index-module.test.ts
+++ b/test/lib/index-module.test.ts
@@ -5,73 +5,74 @@ import * as debug from 'debug';
 
 import { getDelta } from '../../src/lib/index';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
-
-const originalLog = console.log;
-let consoleOutput: Array<string> = [];
-const mockedLog = (output: string): void => {
-  consoleOutput.push(output);
-};
-beforeAll(() => {
-  console.log = mockedLog;
-});
-
-beforeEach(() => {
-  consoleOutput = [];
-});
-afterAll(() => {
-  setTimeout(() => {
-    console.log = originalLog;
-  }, 500);
-});
-
-beforeEach(() => {
-  return nock('https://snyk.io')
-    .persist()
-    .post(/.*/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/test-goof-aggregated-one-vuln.json',
-          );
-        case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/test-goof-aggregated-one-vuln.json',
-          );
-        case '/api/v1/org/playground/projects':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponsesForProjects/list-all-projects-org-playground.json',
-          );
-        default:
-      }
-    })
-    .get(/.*/)
-    .reply(200, (uri) => {
-      console.log(uri);
-      switch (uri) {
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
-          );
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
-          );
-        case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
-          );
-        default:
-      }
-    });
-});
-
 describe('Test End 2 End - Module', () => {
+  const originalLog = console.log;
+  let consoleOutput: Array<string> = [];
+  const mockedLog = (output: string): void => {
+    consoleOutput.push(output);
+  };
+
+  beforeAll(() => {
+    console.log = mockedLog;
+  });
+
+  beforeEach(() => {
+    consoleOutput = [];
+  });
+  afterAll(() => {
+    jest.resetAllMocks();
+    setTimeout(() => {
+      console.log = originalLog;
+    }, 500);
+  });
+
+  beforeEach(() => {
+    return nock('https://snyk.io')
+      .persist()
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/api/v1/org/playground/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/api/v1/org/playground/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-playground.json',
+            );
+          default:
+        }
+      })
+      .get(/.*/)
+      .reply(200, (uri) => {
+        console.log(uri);
+        switch (uri) {
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
+            );
+          case '/api/v1/org/playground/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
+            );
+          default:
+        }
+      });
+  });
+
   it('Test module mode - no new issue', async () => {
     const result = await getDelta(
       fs

--- a/test/lib/index-module.test.ts
+++ b/test/lib/index-module.test.ts
@@ -179,8 +179,18 @@ describe('Test End 2 End - Module', () => {
 
     expect(result).toEqual(expectedResult);
   });
+  it('Test module mode - invalid json input', async () => {
+    const result = await getDelta(JSON.stringify({}));
+    expect(result).toEqual({
+      newLicenseIssues: undefined,
+      newVulns: undefined,
+      noBaseline: true,
+      passIfNoBaseline: false,
+      result: 2,
+    });
+  });
 
-  it('Test module mode - 1 new issue fail - fail-on upgradable only', async () => {
+  it('Test module mode - 1 new issue fail --fail-on upgradable only', async () => {
     const result = await getDelta(
       fs
         .readFileSync(

--- a/test/lib/snyk/issues.test.ts
+++ b/test/lib/snyk/issues.test.ts
@@ -20,6 +20,9 @@ import { convertIntoIssueWithPath } from '../../../src/lib/utils/issuesUtils';
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
 
 describe('Test issues functions', () => {
+  beforeAll(() => {
+    jest.resetAllMocks();
+  });
   describe('Test getNewVulns', () => {
     it('Test getNewVulns - inline mode - no new vuln', async () => {
       utils.init();

--- a/test/lib/utils/utils.test.ts
+++ b/test/lib/utils/utils.test.ts
@@ -4,6 +4,9 @@ import { stdin, MockSTDIN } from 'mock-stdin';
 const stdinMock: MockSTDIN = stdin();
 
 describe('Test utils functions', () => {
+  beforeAll(() => {
+    jest.resetAllMocks();
+  });
   it('Test getPipedDataIn', async () => {
     setTimeout(() => {
       stdinMock.send('Some text', 'ascii');


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
- baseline org is `undefined` by default
- check the baseline org is set one way or another ot throw
- check we have `.vulnerabilities` to work with from `snyk test --json` output
### Screenshots
Throw if `snyk monitor` is the input by accident, before we failed with a runtime error as we fail to `.filter`

<img width="978" alt="CleanShot 2022-07-05 at 10 52 58@2x" src="https://user-images.githubusercontent.com/2911613/177302009-2cdf4ea8-0bbb-4896-99da-2b327ac06f8c.png">
