### PR TITLE
fix: compile for node 12+

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,8 @@
   "compilerOptions": {
     "outDir": "./dist",
     "pretty": true,
-    "target": "esnext",
+    "target": "es2017",
+    "lib": ["es2017"],
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Ensure `npm` package supports Node.js 12 not just 14+