### PR TITLE
fix: apply type filter before computing exit code

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -44,7 +44,9 @@ const getDelta = async (
     type?: string;
   } = utils.init(debugMode);
   const debug = utils.getDebugModule();
-
+  if (process.env.NODE_ENV == 'test') {
+    argv.type = process.env.TYPE? process.env.TYPE : 'all'
+  }
   const mode = argv.currentProject ?? argv.currentOrg ? 'standalone' : 'inline';
   debug(mode, 'mode');
   const passIfNoBaseline = argv.setPassIfNoBaseline ?? setPassIfNoBaselineFlag;
@@ -241,15 +243,23 @@ const getDelta = async (
     ) {
       displayOutput(newVulns, newLicenseIssues, issueTypeFilter, mode);
     }
-
-    if (newVulns.length + newLicenseIssues.length > 0) {
+    
+    const issuesFilter = []
+    if(issueTypeFilter == 'vulns'){
+      issuesFilter.push(...newVulns)
+    } else if(issueTypeFilter == 'license'){
+      issuesFilter.push(...newLicenseIssues)
+    } else {
+      issuesFilter.push(...newVulns,...newLicenseIssues)
+    }
+    if (issuesFilter.length > 0) {
       if (!baselineProjectPublicID && passIfNoBaseline) {
         process.exitCode = 0;
       } else {
         process.exitCode = computeFailCode(
           newVulns,
           newLicenseIssues,
-          failOnFixableSetting,
+          failOnFixableSetting
         );
       }
     } else {

--- a/src/lib/snyk/snyk_utils.ts
+++ b/src/lib/snyk/snyk_utils.ts
@@ -16,12 +16,12 @@ function getConfig(): { endpoint: string; token: string } {
 function computeFailCode(
   vulns: IssueWithPaths[],
   licenseIssues: IssueWithPaths[],
-  failOnFixableSetting?: string,
+  failOnFixableSetting?: string
 ): number {
   const debug = getDebugModule();
 
   let exitCodeToReturn = 1;
-
+  
   const issues = [...vulns, ...licenseIssues];
   switch (failOnFixableSetting) {
     case 'upgradable':


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes the issue type filter that was ignored in the exit code computation.
Also fixing a exit code mock issue in test.