### PR TITLE
fix: typo in filter type in exit code

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -245,7 +245,7 @@ const getDelta = async (
     }
     
     const issuesFilter = []
-    if(issueTypeFilter == 'vulns'){
+    if(issueTypeFilter == 'vuln'){
       issuesFilter.push(...newVulns)
     } else if(issueTypeFilter == 'license'){
       issuesFilter.push(...newLicenseIssues)

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -403,4 +403,35 @@ describe('Test End 2 End - Inline mode', () => {
 
     expect(mockExit).toHaveBeenCalledWith(0);
   });
+
+  it('Test Inline mode - no new issue if license filter on', async () => {
+    process.env.TYPE = 'vuln';
+    setTimeout(() => {
+      stdinMock.send(
+        fs
+          .readFileSync(
+            fixturesFolderPath + 'snykTestsOutputs/test-goof-two-vuln.json',
+          )
+          .toString(),
+      );
+      stdinMock.send(null);
+    }, 100);
+
+    await getDelta();
+
+    const expectedOutput = [
+      'New issue introduced !',
+      'Security Vulnerability:',
+      '  1/1: Prototype Pollution [Medium Severity]',
+      '    Via: snyk@1.228.3 => configstore@3.1.2 => dot-prop@4.2.0',
+      '    Fixed in: dot-prop 5.1.1',
+      '    Fixable by upgrade:  snyk@1.290.1',
+    ];
+
+    expectedOutput.forEach((line: string) => {
+      expect(consoleOutput.join()).toContain(line);
+    });
+
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes typo, vulns != vuln.
