### PR TITLE
feat: add org slug to orgUUID resolution for better v3 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "is-uuid": "^1.0.2",
     "lodash": "^4.17.15",
     "snyk-api-ts-client": "1.11.1",
+    "snyk-request-manager": "^1.8.1",
     "source-map-support": "^0.5.16",
     "terminal-link": "^2.1.1",
     "tslib": "^1.10.0",

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -110,7 +110,8 @@ const getDelta = async (
         : `${projectName}`;
 
       if (!baselineOrgPublicId) {
-        baselineOrgPublicId = org;
+        // swap out org slug for org ID
+        baselineOrgPublicId = !isUUID.anyNonNil(org) ? await snyk.getOrgUUID(org) : org
       }
 
       if (!baselineOrgPublicId) {

--- a/test/fixtures/apiResponses/customerorgSlugToUUID.json
+++ b/test/fixtures/apiResponses/customerorgSlugToUUID.json
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "attributes": {
+        "group_id": "1234-1234-1234-1234-1234567890ab",
+        "is_personal": false,
+        "name": "customerorg",
+        "slug": "customerorg"
+      },
+      "id": "1234-1234-1234-1234-123456789012",
+      "type": "org"
+    }
+  ],
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+    "prev": "/rest/orgs?ending_before=v1.eyJuYW1lIjoiYW50b2luZSBwbGF5Z3JvdW5kIiwic2x1ZyI6ImFudG9pbmUtcGxheWdyb3VuZCJ9&limit=10&slug=customerorg&version=2023-05-29"
+  }
+}

--- a/test/fixtures/apiResponses/emptyorgSlugToUUID.json
+++ b/test/fixtures/apiResponses/emptyorgSlugToUUID.json
@@ -1,0 +1,9 @@
+{
+  "data": [],
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "links": {
+    "prev": "/rest/orgs?ending_before=v1.eyJuYW1lIjoiYW50b2luZSBwbGF5Z3JvdW5kIiwic2x1ZyI6ImFudG9pbmUtcGxheWdyb3VuZCJ9&limit=10&slug=customerorg&version=2023-05-29"
+  }
+}

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -54,6 +54,10 @@ describe('Test End 2 End - Inline mode', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
             );
+          case '/rest/orgs?version=2023-06-22~beta&limit=10&slug=customerorg':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/customerorgSlugToUUID.json',
+            );
           default:
         }
       });
@@ -82,7 +86,7 @@ describe('Test End 2 End - Inline mode', () => {
               fixturesFolderPath +
                 'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
             );
-          case '/api/v1/org/customerorg/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/aggregated-issues':
+          case '/api/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/projectId-aggregated-issues.json',
@@ -107,7 +111,7 @@ describe('Test End 2 End - Inline mode', () => {
               fixturesFolderPath +
                 'apiResponses/java-goof-todolist-core-depgraph.json',
             );
-          case '/api/v1/org/customerorg/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/dep-graph':
+          case '/api/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'dependencies/projectId-depgraph.json',
             );

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -7,6 +7,7 @@ import {
   getProjectIssues,
   getProjectDepGraph,
   getProjectUUID,
+  getOrgUUID,
 } from '../../../src/lib/snyk/snyk';
 import * as Error from '../../../src/lib/customErrors/apiError';
 
@@ -86,6 +87,15 @@ beforeEach(() => {
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
           );
+        case '/rest/orgs?version=2023-06-22~beta&limit=10&slug=customerorg':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/customerorgSlugToUUID.json',
+          );
+        case '/rest/orgs?version=2023-06-22~beta&limit=10&slug=customerorg2':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/emptyorgSlugToUUID.json',
+          );
+
         default:
       }
     });
@@ -95,6 +105,15 @@ describe('Test endpoint functions', () => {
   it('Test GetProject', async () => {
     const project = await getProject('123', '123');
     expect(project).toEqual('project');
+  });
+
+  it('Test GetOrgUUID', async () => {
+    const project = await getOrgUUID('customerorg');
+    expect(project).toEqual('1234-1234-1234-1234-123456789012');
+  });
+  it('Test GetOrgUUID non existing org', async () => {
+    const project = await getOrgUUID('customerorg2');
+    expect(project).toEqual('');
   });
 
   it('Test GetProjectUUID', async () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist",
     "pretty": true,
     "target": "es2017",
-    "lib": ["es2017"],
+    "lib": ["es2017", "DOM"],
     "module": "commonjs",
     "moduleResolution": "node",
     "sourceMap": true,


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Swaps out organization slugs for UUID for better compatibility with v3 API and support in other tools depending on snyk-delta.

### Notes for the reviewer

In api v1, org slugs and org ID could pretty much be used interchangeably. The CLI json output includes the org slug. Since REST api are more opinionated about the org identifier being a UUID, adding a org slug to org UUID resolution step.
It is needed to support snyk-delta version getting off projects v1 API in snyk-prevent-gh-commit-status.
