### PR TITLE
fix: use specific semantic release version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
                 fail-on-issues: true
                 monitor-on-build: true
                 token-variable: SNYK_TOKEN
-            - run: ./node_modules/.bin/semantic-release semantic-release
+            - run: npx semantic-release@23.1.0
     build-test:
         docker:
             - image: cimg/node:18.17.1


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Uses a particular version before the execa dep version upgrade in semantic release