### PR TITLE
fix: use specific semantic release version for node18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
                 fail-on-issues: true
                 monitor-on-build: true
                 token-variable: SNYK_TOKEN
-            - run: npx semantic-release@23.1.0
+            - run: npx semantic-release@22.0.12
     build-test:
         docker:
             - image: cimg/node:18.17.1


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Pin semantic release correct version for node 18 support.

### Notes for the reviewer

Semantic release versions 23 and above drop node 18 support.