### PR TITLE
fix: bump orgs api endpt off deprecated version

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -17,8 +17,13 @@ ignore:
   SNYK-JS-AXIOS-6124857:
     - '*':
         reason: REDOS Not applicable in such cli tool.
-        expires: 2024-10-31T12:02:05.327Z
-        created: 2024-10-01T12:02:05.330Z
+        expires: 2025-02-12T13:39:43.795Z
+        created: 2025-01-13T13:39:43.798Z
+  SNYK-JS-AXIOS-6671926:
+    - '*':
+        reason: XSS Not applicable in such cli tool.
+        expires: 2025-02-12T13:40:05.484Z
+        created: 2025-01-13T13:40:05.491Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-450202:

--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,5 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.25.0
+version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JS-AXIOS-1579269:
@@ -11,9 +11,9 @@ ignore:
         expires: '2021-10-03T13:14:14.049Z'
   SNYK-JS-AXIOS-6032459:
     - '*':
-        reason: Not applicable in such cli tool.snoozing temporarily.
-        expires: 2024-10-31T11:59:43.057Z
-        created: 2024-10-01T11:59:43.064Z
+        reason: REDOS Not applicable in such cli tool.
+        expires: 2025-02-12T13:35:06.163Z
+        created: 2025-01-13T13:35:06.166Z
   SNYK-JS-AXIOS-6124857:
     - '*':
         reason: REDOS Not applicable in such cli tool.

--- a/src/lib/snyk/snyk.ts
+++ b/src/lib/snyk/snyk.ts
@@ -15,7 +15,7 @@ async function getOrgUUID(orgSlug: string): Promise<string> {
   let orgUUID = '';
 
   let url = '/orgs';
-  const urlQueryParams: Array<string> = ['version=2023-06-22~beta', 'limit=10',`slug=${orgSlug}`];
+  const urlQueryParams: Array<string> = ['version=2024-10-15', 'limit=10',`slug=${orgSlug}`];
 
   if (urlQueryParams.length > 0) {
     url += `?${urlQueryParams.join('&')}`;

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -54,7 +54,7 @@ describe('Test End 2 End - Inline mode', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
             );
-          case '/rest/orgs?version=2023-06-22~beta&limit=10&slug=customerorg':
+          case '/rest/orgs?version=2024-10-15&limit=10&slug=customerorg':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/customerorgSlugToUUID.json',
             );

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -87,11 +87,11 @@ beforeEach(() => {
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
           );
-        case '/rest/orgs?version=2023-06-22~beta&limit=10&slug=customerorg':
+        case '/rest/orgs?version=2024-10-15&limit=10&slug=customerorg':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/customerorgSlugToUUID.json',
           );
-        case '/rest/orgs?version=2023-06-22~beta&limit=10&slug=customerorg2':
+        case '/rest/orgs?version=2024-10-15&limit=10&slug=customerorg2':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/emptyorgSlugToUUID.json',
           );


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps api version for /orgs off deprecated beta version to ga one.

