### PR TITLE
Fix/rm snyk api ts client dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "debug": "^4.1.1",
     "is-uuid": "^1.0.2",
     "lodash": "^4.17.15",
-    "snyk-api-ts-client": "^1.11.2",
     "snyk-request-manager": "^1.8.6",
     "source-map-support": "^0.5.16",
     "terminal-link": "^2.1.1",

--- a/src/lib/snyk/aggregatedIssues.ts
+++ b/src/lib/snyk/aggregatedIssues.ts
@@ -1,0 +1,137 @@
+import * as Error from '../customErrors/apiError';
+import { createFromJSON, DepGraph, DepGraphData } from '@snyk/dep-graph';
+import { AggregatedissuesPostResponseType } from './issuesTypes';
+import { requestsManager } from 'snyk-request-manager';
+
+interface IssuesWithVulnsPaths {
+  issues: {
+    pkgVersionsWithPaths: { [key: string]: Array<Array<string>> }[];
+  }[];
+}
+
+export type AggregatedIssuesWithVulnPaths = IssuesWithVulnsPaths &
+  AggregatedissuesPostResponseType;
+
+const getVulnPathsForPkgVersionFromGraph = (
+  pkgName: string,
+  version: string,
+  depGraph: DepGraph,
+): Array<Array<string>> => {
+  const pkg = {
+    name: pkgName,
+    version: version,
+  };
+
+  // Handle binaries vulns that aren't always in the depgraph (like base image stuff). Adding them as top level path.
+  if (
+    !depGraph
+      .getPkgs()
+      .map((depPkgInfo) => `${depPkgInfo.name}@${depPkgInfo.version}`)
+      .includes(`${pkgName}@${version}`)
+  ) {
+    return [[`${pkgName}@${version}`]];
+  } else {
+    const pkgVulnPaths = depGraph.pkgPathsToRoot(pkg) as Array<
+      Array<{ name: string; version?: string }>
+    >;
+    return pkgVulnPaths.map((vulnPath) =>
+      vulnPath
+        .map((vulnPathPkg) => `${vulnPathPkg.name}@${vulnPathPkg.version}`)
+        .reverse()
+        .slice(1),
+    );
+  }
+};
+
+export const getAggregatedIssuesWithVulnPaths = async (
+  requestManager: requestsManager,
+  orgID: string,
+  projectID: string,
+): Promise<AggregatedIssuesWithVulnPaths> => {
+  const url = `/org/${orgID}/project/${projectID}/aggregated-issues`;
+  // No filter on patched or non patch issue, getting both
+  const filters = {
+    includeDescription: false,
+    includeIntroducedThrough: false,
+    filters: {
+      severities: ['high', 'medium', 'low', 'critical'],
+      exploitMaturity: [
+        'mature',
+        'proof-of-concept',
+        'no-known-exploit',
+        'no-data',
+      ],
+      types: ['vuln', 'license'],
+      ignored: false,
+      patched: false,
+      priority: {
+        score: {
+          min: undefined,
+          max: undefined,
+        },
+      },
+    },
+  };
+  try {
+    const projectAggregatedIssues = await requestManager.request({
+      verb: 'POST',
+      url: url,
+      body: JSON.stringify(filters),
+    });
+    if (!projectAggregatedIssues.data) {
+      throw new Error.NotFoundError(
+        `No aggregated issues data found for ${projectID} from org ${orgID}.`,
+      );
+    }
+
+    const projectAggregatedIssuesData = projectAggregatedIssues.data as AggregatedissuesPostResponseType;
+
+    const depGraphUrl = `/org/${orgID}/project/${projectID}/dep-graph`;
+    const projectDepGraph = await requestManager.request({
+      verb: 'GET',
+      url: depGraphUrl,
+    });
+    if (!projectDepGraph.data || !projectDepGraph.data.depGraph) {
+      throw new Error.NotFoundError(
+        `No depgraph data found for ${projectID} from org ${orgID}.`,
+      );
+    }
+
+    const depGraph = createFromJSON(
+      projectDepGraph.data.depGraph as DepGraphData,
+    );
+
+    const returnData: AggregatedIssuesWithVulnPaths = {
+      issues: [],
+    };
+
+    projectAggregatedIssuesData?.issues?.map((issue) => {
+      const returnVulnPathsData = issue.pkgVersions.map((version) => {
+        const pkg = {
+          name: issue.pkgName,
+          version: version as string,
+        };
+        return {
+          [`${pkg.version}`]: getVulnPathsForPkgVersionFromGraph(
+            pkg.name,
+            pkg.version,
+            depGraph,
+          ),
+        };
+      });
+
+      const newIssue = {
+        pkgVersionsWithPaths: returnVulnPathsData,
+        ...issue,
+      };
+
+      returnData.issues.push(newIssue);
+    });
+
+    return returnData;
+  } catch (err) {
+    throw new Error.GenericError(
+      `Error getting project ${projectID} from org ${orgID}: ${err}.`,
+    );
+  }
+};

--- a/src/lib/snyk/depgraphTypes.ts
+++ b/src/lib/snyk/depgraphTypes.ts
@@ -1,0 +1,77 @@
+export interface DepgraphGetResponseType {
+    /**
+     * The dependency-graph object
+     */
+    depGraph: {
+        /**
+         * The scheme version of the depGraph object
+         */
+        schemaVersion: string;
+        /**
+         * The package manager of the project
+         */
+        pkgManager: {
+            /**
+             * The name of the package manager
+             */
+            name: string;
+            /**
+             * The version of the package manager
+             */
+            version?: string;
+            repositories?: {
+                alias: string;
+            }[];
+        };
+        /**
+         * A list of dependencies in the project
+         */
+        pkgs: {
+            /**
+             * The internal id of the package
+             */
+            id: string;
+            info: {
+                /**
+                 * The name of the package
+                 */
+                name: string;
+                /**
+                 * The version of the package
+                 */
+                version?: string;
+            };
+        }[];
+        /**
+         * A directional graph of the packages in the project
+         */
+        graph: {
+            /**
+             * The internal id of the root node
+             */
+            rootNodeId: string;
+            /**
+             * A list of the first-level packages
+             */
+            nodes?: {
+                /**
+                 * The internal id of the node
+                 */
+                nodeId: string;
+                /**
+                 * The id of the package
+                 */
+                pkgId: string;
+                /**
+                 * A list of the direct dependencies of the package
+                 */
+                deps: {
+                    /**
+                     * The id of the node
+                     */
+                    nodeId: string;
+                }[];
+            }[];
+        };
+    };
+}

--- a/src/lib/snyk/issuesTypes.ts
+++ b/src/lib/snyk/issuesTypes.ts
@@ -1,0 +1,288 @@
+export interface AggregatedissuesPostBodyType {
+    /**
+     * If set to `true`, Include issue's description, if set to `false` (by default), it won't (Non-IaC projects only)
+     */
+    includeDescription?: boolean;
+    /**
+     * If set to `true`, Include issue's introducedThrough, if set to `false` (by default), it won't. It's for container only projects (Non-IaC projects only)
+     */
+    includeIntroducedThrough?: boolean;
+    filters?: {
+        /**
+         * The severity levels of issues to filter the results by
+         */
+        severities?: string[];
+        /**
+         * The exploit maturity levels of issues to filter the results by (Non-IaC projects only)
+         */
+        exploitMaturity?: string[];
+        /**
+         * The type of issues to filter the results by (Non-IaC projects only)
+         */
+        types?: string[];
+        /**
+         * If set to `true`, only include issues which are ignored, if set to `false`, only include issues which are not ignored
+         */
+        ignored?: boolean;
+        /**
+         * If set to `true`, only include issues which are patched, if set to `false`, only include issues which are not patched (Non-IaC projects only)
+         */
+        patched?: boolean;
+        /**
+         * The priority to filter the issues by (Non-IaC projects only)
+         */
+        priority?: {
+            /**
+             * Include issues where the priority score is between min and max
+             */
+            score?: {
+                min?: number;
+                max?: number;
+            };
+        };
+    };
+}
+
+export interface AggregatedissuesPostResponseType {
+    /**
+     * An array of identified issues
+     */
+    issues?: {
+        /**
+         * The identifier of the issue
+         */
+        id: string;
+        /**
+         * type of the issue ('vuln', 'license' or 'configuration')
+         */
+        issueType: string;
+        /**
+         * The package name (Non-IaC projects only)
+         */
+        pkgName: string;
+        /**
+         * List of affected package versions (Non-IaC projects only)
+         */
+        pkgVersions: string[];
+        /**
+         * The details of the issue
+         */
+        issueData: {
+            /**
+             * The identifier of the issue
+             */
+            id: string;
+            /**
+             * The issue title
+             */
+            title: string;
+            /**
+             * The severity status of the issue, after policies are applied
+             */
+            severity: string;
+            /**
+             * The original severity status of the issue, as retrieved from Snyk Vulnerability database, before policies are applied
+             */
+            originalSeverity: string;
+            /**
+             * URL to a page containing information about the issue
+             */
+            url: string;
+            description: string;
+            /**
+             * External identifiers assigned to the issue (Non-IaC projects only)
+             */
+            identifiers: {
+                /**
+                 * Common Vulnerability Enumeration identifiers
+                 */
+                CVE?: string[];
+                /**
+                 * Common Weakness Enumeration identifiers
+                 */
+                CWE?: string[];
+                /**
+                 * Identifiers assigned by the Open Source Vulnerability Database (OSVDB)
+                 */
+                OSVDB?: string[];
+            };
+            /**
+             * The list of people responsible for first uncovering or reporting the issue (Non-IaC projects only)
+             */
+            credit: string[];
+            /**
+             * The exploit maturity of the issue
+             */
+            exploitMaturity: string;
+            /**
+             * The ranges that are vulnerable and unaffected by the issue (Non-IaC projects only)
+             */
+            semver: {
+                /**
+                 * The ranges that are vulnerable to the issue. May be an array or a string.
+                 */
+                vulnerable?: string[];
+                /**
+                 * The ranges that are unaffected by the issue
+                 */
+                unaffected?: string;
+            };
+            /**
+             * The date that the vulnerability was first published by Snyk (Non-IaC projects only)
+             */
+            publicationTime: string;
+            /**
+             * The date that the vulnerability was first disclosed
+             */
+            disclosureTime: string;
+            /**
+             * The CVSS v3 string that signifies how the CVSS score was calculated (Non-IaC projects only)
+             */
+            CVSSv3: string;
+            /**
+             * The CVSS score that results from running the CVSSv3 string (Non-IaC projects only)
+             */
+            cvssScore: number;
+            /**
+             * The language of the issue (Non-IaC projects only)
+             */
+            language: string;
+            /**
+             * A list of patches available for the given issue (Non-IaC projects only)
+             */
+            patches: string[];
+            /**
+             * Nearest version which includes a fix for the issue. This is populated for container projects only. (Non-IaC projects only)
+             */
+            nearestFixedInVersion: string;
+            /**
+             * Path to the resource property violating the policy within the scanned project. (IaC projects only)
+             */
+            path: string;
+            /**
+             * The ID of the violated policy in the issue (IaC projects only)
+             */
+            violatedPolicyPublicId: string;
+            /**
+             * Whether the issue is intentional, indicating a malicious package
+             */
+            isMaliciousPackage: boolean;
+        };
+        /**
+         * The list of what introduced the issue (it is available only for container project with Dockerfile)
+         */
+        introducedThrough?: string[];
+        /**
+         * Whether the issue has been patched (Non-IaC projects only)
+         */
+        isPatched: boolean;
+        /**
+         * Whether the issue has been ignored
+         */
+        isIgnored: boolean;
+        /**
+         * The list of reasons why the issue was ignored
+         */
+        ignoreReasons?: string[];
+        /**
+         * Information about fix/upgrade/pinnable options for the issue (Non-IaC projects only)
+         */
+        fixInfo?: {
+            /**
+             * Whether all of the issue's paths are upgradable
+             */
+            isUpgradable?: boolean;
+            /**
+             * Whether the issue can be fixed by pinning a transitive
+             */
+            isPinnable?: boolean;
+            /**
+             * Whether all the of issue's paths are patchable
+             */
+            isPatchable?: boolean;
+            /**
+             * Whether all of the issue's paths are fixable. Paths that are already patched are not considered fixable unless they have an alternative remediation (e.g. pinning or upgrading). An upgrade path where the only changes are in transitive dependencies is only considered fixable if the package manager supports it.
+             */
+            isFixable?: boolean;
+            /**
+             * Whether any of the issue's paths can be fixed. Paths that are already patched are not considered fixable unless they have an alternative remediation (e.g. pinning or upgrading).  An upgrade path where the only changes are in transitive dependencies is only considered fixable if the package manager supports it.
+             */
+            isPartiallyFixable?: boolean;
+            /**
+             * Nearest version which includes a fix for the issue. This is populated for container projects only.
+             */
+            nearestFixedInVersion?: string;
+            /**
+             * The set of versions in which this issue has been fixed. If the issue spanned multiple versions (i.e. `1.x` and `2.x`) then there will be multiple `fixedIn` entries
+             */
+            fixedIn?: string[];
+        };
+        /**
+         * Information about the priority of the issue (Non-IaC projects only)
+         */
+        priority?: {
+            /**
+             * The priority score of the issue
+             */
+            score?: number;
+            /**
+             * The list of factors that contributed to the priority of the issue
+             */
+            factors?: string[];
+        };
+        /**
+         * Onward links from this record (Non-IaC projects only)
+         */
+        links?: {
+            /**
+             * The URL for the dependency paths that introduce this issue
+             */
+            paths?: string;
+        };
+    }[];
+}
+
+export interface PathsGetResponseType {
+    /**
+     * The identifier of the snapshot for which the paths have been found
+     */
+    snapshotId?: string;
+    /**
+     * A list of the dependency paths that introduce the issue
+     */
+    paths?: {
+        /**
+         * The package name
+         */
+        name?: string;
+        /**
+         * The package version
+         */
+        version?: string;
+        /**
+         * The version to upgrade the package to in order to resolve the issue. This will only appear on the first element of the path, and only if the issue can be fixed by upgrading packages. Note that if the fix requires upgrading transitive dependencies, `fixVersion` will be the same as `version`.
+         */
+        fixVersion?: string;
+    }[][];
+    /**
+     * The total number of results
+     */
+    total?: number;
+    /**
+     * Onward links from this record
+     */
+    links?: {
+        /**
+         * The URL of the previous page of paths for the issue, if not on the first page
+         */
+        prev?: string;
+        /**
+         * The URL of the next page of paths for the issue, if not on the last page
+         */
+        next?: string;
+        /**
+         * The URL of the last page of paths for the issue
+         */
+        last?: string;
+    };
+}

--- a/src/lib/snyk/projectTypes.ts
+++ b/src/lib/snyk/projectTypes.ts
@@ -1,0 +1,905 @@
+/* tslint:disable */
+/* eslint-disable */
+
+export interface AutoDependencyUpgradeSettings {
+    /**
+     * Dependencies which should NOT be included in an automatic upgrade operation.
+     * @type {Array<string>}
+     * @memberof AutoDependencyUpgradeSettings
+     */
+    ignoredDependencies?: Array<string>;
+    /**
+     * Automatically raise pull requests to update out-of-date dependencies.
+     * @type {boolean}
+     * @memberof AutoDependencyUpgradeSettings
+     */
+    isEnabled?: boolean;
+    /**
+     * Apply the auto dependency integration settings of the Organization to this project.
+     * @type {boolean}
+     * @memberof AutoDependencyUpgradeSettings
+     */
+    isInherited?: boolean;
+    /**
+     * Include major version in dependency upgrade recommendation.
+     * @type {boolean}
+     * @memberof AutoDependencyUpgradeSettings
+     */
+    isMajorUpgradeEnabled?: boolean;
+    /**
+     * Limit of dependency upgrade PRs which can be opened simultaneously. When the limit is reached, no new upgrade PRs are created. If specified, must be between 1 and 10.
+     * @type {number}
+     * @memberof AutoDependencyUpgradeSettings
+     */
+    limit?: number;
+    /**
+     * Minimum dependency maturity period in days. If specified, must be between 1 and 365.
+     * @type {number}
+     * @memberof AutoDependencyUpgradeSettings
+     */
+    minimumAge?: number;
+  }
+  
+  export interface AutoRemediationPRsSettings {
+    /**
+     * Automatically create pull requests on scheduled tests for known (backlog) vulnerabilities.
+     * @type {boolean}
+     * @memberof AutoRemediationPRsSettings
+     */
+    isBacklogPrsEnabled?: boolean;
+    /**
+     * Automatically create pull requests on scheduled tests for new vulnerabilities.
+     * @type {boolean}
+     * @memberof AutoRemediationPRsSettings
+     */
+    isFreshPrsEnabled?: boolean;
+    /**
+     * Include vulnerability patches in automatic pull requests.
+     * @type {boolean}
+     * @memberof AutoRemediationPRsSettings
+     */
+    isPatchRemediationEnabled?: boolean;
+  }
+  
+  export interface ManualRemediationPRsSettings {
+    /**
+     * Include vulnerability patches in manual pull requests.
+     * @type {boolean}
+     * @memberof ManualRemediationPRsSettings
+     */
+    isPatchRemediationEnabled?: boolean;
+  }
+  
+  export interface PullRequestAssignmentSettings {
+    /**
+     * Manually specify users to assign (and all will be assigned).
+     * @type {Array<string>}
+     * @memberof PullRequestAssignmentSettings
+     */
+    assignees?: Array<string>;
+    /**
+     * Automatically assign pull requests created by Snyk.
+     * @type {boolean}
+     * @memberof PullRequestAssignmentSettings
+     */
+    isEnabled?: boolean;
+    /**
+     * Automatically assign the last user to change the manifest file (\"auto\"), or manually specify a list of users (\"manual\").
+     * @type {string}
+     * @memberof PullRequestAssignmentSettings
+     */
+    type?: PullRequestAssignmentSettingsTypeEnum;
+  }
+  
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum PullRequestAssignmentSettingsTypeEnum {
+    Auto = 'auto',
+    Manual = 'manual',
+  }
+  
+  export interface PullRequestsSettings {
+    /**
+     * Only fail when the issues found have a fix available.
+     * @type {boolean}
+     * @memberof PullRequestsSettings
+     */
+    failOnlyForIssuesWithFix?: boolean;
+    /**
+     * Fail if the project has any issues (\"all\"), or fail if a PR is introducing a new dependency with issues (\"only_new\").
+     * @type {string}
+     * @memberof PullRequestsSettings
+     */
+    policy?: PullRequestsSettingsPolicyEnum;
+    /**
+     * Only fail for issues greater than or equal to the specified severity.
+     * @type {string}
+     * @memberof PullRequestsSettings
+     */
+    severityThreshold?: PullRequestsSettingsSeverityThresholdEnum;
+  }
+  
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum PullRequestsSettingsPolicyEnum {
+    All = 'all',
+    OnlyNew = 'only_new',
+  }
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum PullRequestsSettingsSeverityThresholdEnum {
+    Low = 'low',
+    Medium = 'medium',
+    High = 'high',
+    Critical = 'critical',
+  }
+  
+  export interface RecurringTestsSettings {
+    /**
+     * Test frequency of a project. Also controls when automated PRs may be created.
+     * @type {string}
+     * @memberof RecurringTestsSettings
+     */
+    frequency?: RecurringTestsSettingsFrequencyEnum;
+  }
+  
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum RecurringTestsSettingsFrequencyEnum {
+    Daily = 'daily',
+    Weekly = 'weekly',
+    Never = 'never',
+  }
+  
+  /**
+   *
+   * @export
+   * @interface ProjectSettings
+   */
+  export interface ProjectSettings {
+    /**
+     *
+     * @type {AutoDependencyUpgradeSettings}
+     * @memberof ProjectSettings
+     */
+    autoDependencyUpgrade?: AutoDependencyUpgradeSettings;
+    /**
+     *
+     * @type {AutoRemediationPRsSettings}
+     * @memberof ProjectSettings
+     */
+    autoRemediationPrs?: AutoRemediationPRsSettings;
+    /**
+     *
+     * @type {ManualRemediationPRsSettings}
+     * @memberof ProjectSettings
+     */
+    manualRemediationPrs?: ManualRemediationPRsSettings;
+    /**
+     *
+     * @type {PullRequestAssignmentSettings}
+     * @memberof ProjectSettings
+     */
+    pullRequestAssignment?: PullRequestAssignmentSettings;
+    /**
+     *
+     * @type {PullRequestsSettings}
+     * @memberof ProjectSettings
+     */
+    pullRequests: PullRequestsSettings;
+    /**
+     *
+     * @type {RecurringTestsSettings}
+     * @memberof ProjectSettings
+     */
+    recurring_tests: RecurringTestsSettings;
+  }
+  
+  export interface ProjectsMeta {
+    /**
+     * The date that the project was last uploaded and monitored using cli.
+     * @type {Date}
+     * @memberof ProjectsMeta
+     */
+    cliMonitoredAt?: Date | null;
+  }
+  
+  export interface ContainerBuildArgs {
+    /**
+     *
+     * @type {string}
+     * @memberof ContainerBuildArgs
+     */
+    platform: string;
+  }
+  
+  export interface NugetBuildArgs {
+    /**
+     *
+     * @type {string}
+     * @memberof NugetBuildArgs
+     */
+    targetFramework: string;
+  }
+  
+  export interface PatchProjectRequestDataAttributesTags {
+    /**
+     *
+     * @type {string}
+     * @memberof PatchProjectRequestDataAttributesTags
+     */
+    key?: string;
+    /**
+     *
+     * @type {string}
+     * @memberof PatchProjectRequestDataAttributesTags
+     */
+    value?: string;
+  }
+  
+  export interface YarnBuildArgs {
+    /**
+     *
+     * @type {string}
+     * @memberof YarnBuildArgs
+     */
+    rootWorkspace?: string;
+  }
+  
+  /**
+   *
+   * @export
+   * @interface ProjectAttributes
+   */
+  export interface ProjectAttributes {
+    /**
+     *
+     * @type {YarnBuildArgs | ContainerBuildArgs | NugetBuildArgs}
+     * @memberof ProjectAttributes
+     */
+    buildArgs?: YarnBuildArgs | ContainerBuildArgs | NugetBuildArgs;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof ProjectAttributes
+     */
+    businessCriticality?: Array<ProjectAttributesBusinessCriticalityEnum>;
+    /**
+     * The date that the project was created on
+     * @type {Date}
+     * @memberof ProjectAttributes
+     */
+    created: Date;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof ProjectAttributes
+     */
+    environment?: Array<ProjectAttributesEnvironmentEnum>;
+    /**
+     *
+     * @type {Array<string>}
+     * @memberof ProjectAttributes
+     */
+    lifecycle?: Array<ProjectAttributesLifecycleEnum>;
+    /**
+     * Project name.
+     * @type {string}
+     * @memberof ProjectAttributes
+     */
+    name: string;
+    /**
+     * The origin the project was added from.
+     * @type {string}
+     * @memberof ProjectAttributes
+     */
+    origin: string;
+    /**
+     *
+     * @type {ProjectSettings}
+     * @memberof ProjectAttributes
+     */
+    settings: ProjectSettings;
+    /**
+     * Describes if a project is currently monitored or it is de-activated.
+     * @type {string}
+     * @memberof ProjectAttributes
+     */
+    status: ProjectAttributesStatusEnum;
+    /**
+     *
+     * @type {Array<PatchProjectRequestDataAttributesTags>}
+     * @memberof ProjectAttributes
+     */
+    tags?: Array<PatchProjectRequestDataAttributesTags>;
+    /**
+     * Path within the target to identify a specific file/directory/image etc. when scanning just part  of the target, and not the entity.
+     * @type {string}
+     * @memberof ProjectAttributes
+     */
+    targetFile: string;
+    /**
+     * The additional information required to resolve which revision of the resource should be scanned.
+     * @type {string}
+     * @memberof ProjectAttributes
+     */
+    target_reference: string;
+    /**
+     * Dotnet Target, for relevant projects
+     * @type {string}
+     * @memberof ProjectAttributes
+     */
+    targetRuntime?: string;
+    /**
+     * The package manager of the project.
+     * @type {string}
+     * @memberof ProjectAttributes
+     */
+    type: string;
+  }
+  
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum ProjectAttributesBusinessCriticalityEnum {
+    Critical = 'critical',
+    High = 'high',
+    Medium = 'medium',
+    Low = 'low',
+  }
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum ProjectAttributesEnvironmentEnum {
+    Frontend = 'frontend',
+    Backend = 'backend',
+    Internal = 'internal',
+    External = 'external',
+    Mobile = 'mobile',
+    Saas = 'saas',
+    Onprem = 'onprem',
+    Hosted = 'hosted',
+    Distributed = 'distributed',
+  }
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum ProjectAttributesLifecycleEnum {
+    Production = 'production',
+    Development = 'development',
+    Sandbox = 'sandbox',
+  }
+  /**
+   * @export
+   * @enum {string}
+   */
+  export enum ProjectAttributesStatusEnum {
+    Active = 'active',
+    Inactive = 'inactive',
+  }
+  
+  export interface RelatedLink {
+    /**
+     *
+     * @type {LinkProperty}
+     * @memberof RelatedLink
+     */
+    related?: LinkProperty;
+  }
+  
+  export interface TargetDataAttributes {
+    /**
+     * The human readable name that represents this target. These are generated based on the provided properties, and the source. In the future we may support updating this value.
+     * @type {string}
+     * @memberof TargetDataAttributes
+     */
+    displayName?: string;
+    /**
+     * The URL for the resource. We do not use this as part of our representation of the identity of the target, as it can      be changed externally to Snyk We are reliant on individual integrations providing us with this value. Currently it is only provided by the CLI
+     * @type {string}
+     * @memberof TargetDataAttributes
+     */
+    url?: string | null;
+  }
+  
+  export interface TargetData {
+    /**
+     *
+     * @type {TargetDataAttributes}
+     * @memberof TargetData
+     */
+    attributes: TargetDataAttributes;
+    /**
+     * The Resource ID.
+     * @type {string}
+     * @memberof TargetData
+     */
+    id: string;
+    /**
+     * The Resource type.
+     * @type {string}
+     * @memberof TargetData
+     */
+    type: string;
+  }
+  
+  export interface DeprecatedRelationshipData {
+    /**
+     *
+     * @type {string}
+     * @memberof DeprecatedRelationshipData
+     */
+    id: string;
+    /**
+     * Type of the related resource
+     * @type {string}
+     * @memberof DeprecatedRelationshipData
+     */
+    type: string;
+  }
+  export interface Relationship {
+    /**
+     *
+     * @type {DeprecatedRelationshipData}
+     * @memberof Relationship
+     */
+    data: DeprecatedRelationshipData;
+    /**
+     *
+     * @type {RelatedLink}
+     * @memberof Relationship
+     */
+    links: RelatedLink;
+    /**
+     *
+     * @type {Meta}
+     * @memberof Relationship
+     */
+  }
+  export interface LinkProperty {}
+  
+  export interface RelatedLink {
+    /**
+     *
+     * @type {LinkProperty}
+     * @memberof RelatedLink
+     */
+    related?: LinkProperty;
+  }
+  
+  export interface Target {
+    /**
+     *
+     * @type {TargetData}
+     * @memberof Target
+     */
+    data: TargetData;
+    /**
+     *
+     * @type {RelatedLink}
+     * @memberof Target
+     */
+    links: RelatedLink;
+  }
+  
+  /**
+   *
+   * @export
+   * @interface ProjectRelationships
+   */
+  export interface ProjectRelationships {
+    /**
+     *
+     * @type {Relationship}
+     * @memberof ProjectRelationships
+     */
+    importer?: Relationship;
+    /**
+     *
+     * @type {Relationship}
+     * @memberof ProjectRelationships
+     */
+    organization: Relationship;
+    /**
+     *
+     * @type {Relationship}
+     * @memberof ProjectRelationships
+     */
+    owner?: Relationship;
+    /**
+     *
+     * @type {Relationship | Target}
+     * @memberof ProjectRelationships
+     */
+    target: Relationship | Target;
+  }
+  
+  /**
+   *
+   * @export
+   * @interface ProjectsData
+   */
+  export interface ProjectsData {
+    /**
+     *
+     * @type {ProjectAttributes}
+     * @memberof ProjectsData
+     */
+    attributes: ProjectAttributes;
+    /**
+     * Resource ID.
+     * @type {string}
+     * @memberof ProjectsData
+     */
+    id: string;
+    /**
+     *
+     * @type {ProjectsMeta}
+     * @memberof ProjectsData
+     */
+    meta?: ProjectsMeta;
+    /**
+     *
+     * @type {ProjectRelationships}
+     * @memberof ProjectsData
+     */
+    relationships?: ProjectRelationships;
+    /**
+     * The Resource type.
+     * @type {string}
+     * @memberof ProjectsData
+     */
+    type: string;
+  }
+
+  export interface ProjectsPostResponseType {
+    org?: {
+        name?: string;
+        /**
+         * The identifier of the org
+         */
+        id?: string;
+    };
+    /**
+     * A list of org's projects
+     */
+    projects?: {
+        name?: string;
+        /**
+         * The project identifier
+         */
+        id?: string;
+        /**
+         * The date that the project was created on
+         */
+        created?: string;
+        /**
+         * The origin the project was added from
+         */
+        origin?: string;
+        /**
+         * The package manager of the project
+         */
+        type?: string;
+        /**
+         * Whether the project is read-only
+         */
+        readOnly?: boolean;
+        /**
+         * The frequency of automated Snyk re-test. Can be 'daily', 'weekly or 'never'
+         */
+        testFrequency?: string;
+        /**
+         * Number of dependencies of the project
+         */
+        totalDependencies?: number;
+        /**
+         * Number of known vulnerabilities in the project, not including ignored issues
+         */
+        issueCountsBySeverity?: {
+            /**
+             * Number of low severity vulnerabilities
+             */
+            low?: number;
+            /**
+             * Number of medium severity vulnerabilities
+             */
+            medium?: number;
+            /**
+             * Number of high severity vulnerabilities
+             */
+            high?: number;
+            /**
+             * Number of critical severity vulnerabilities
+             */
+            critical?: number;
+        };
+        /**
+         * For docker projects shows the ID of the image
+         */
+        imageId?: string;
+        /**
+         * For docker projects shows the tag of the image
+         */
+        imageTag?: string;
+        /**
+         * For docker projects shows the base image
+         */
+        imageBaseImage?: string;
+        /**
+         * For docker projects shows the platform of the image
+         */
+        imagePlatform?: string;
+        /**
+         * For Kubernetes projects shows the origin cluster name
+         */
+        imageCluster?: string;
+        /**
+         * The project remote repository url. Only set for projects imported via the Snyk CLI tool.
+         */
+        remoteRepoUrl?: string;
+        /**
+         * The date on which the most recent test was conducted for this project
+         */
+        lastTestedDate?: string;
+        /**
+         * The user who owns the project, null if not set
+         *
+         * {
+         *     "id": "e713cf94-bb02-4ea0-89d9-613cce0caed2",
+         *     "name": "example-user@snyk.io",
+         *     "username": "exampleUser",
+         *     "email": "example-user@snyk.io"
+         * }
+         */
+        owner?: object | null;
+        /**
+         * URL with project overview
+         */
+        browseUrl?: string;
+        /**
+         * The user who imported the project
+         */
+        importingUser?: {
+            /**
+             * The ID of the user.
+             */
+            id?: string;
+            /**
+             * The name of the user.
+             */
+            name?: string;
+            /**
+             * The username of the user.
+             */
+            username?: string;
+            /**
+             * The email of the user.
+             */
+            email?: string;
+        };
+        /**
+         * Describes if a project is currently monitored or it is de-activated
+         */
+        isMonitored?: boolean;
+        /**
+         * The monitored branch (if available)
+         */
+        branch?: string | null;
+        /**
+         * The identifier for which revision of the resource is scanned by Snyk. For example this may be a branch for SCM project, or a tag for a container image
+         */
+        targetReference?: string | null;
+        /**
+         * List of applied tags
+         */
+        tags?: string[];
+        /**
+         * Applied project attributes
+         */
+        attributes?: {
+            criticality?: string[];
+            environment?: string[];
+            lifecycle?: string[];
+        };
+    }[];
+}
+export interface ProjectGetResponseType {
+    name?: string;
+    /**
+     * The project identifier
+     */
+    id?: string;
+    /**
+     * The date that the project was created on
+     */
+    created?: string;
+    /**
+     * The origin the project was added from
+     */
+    origin?: string;
+    /**
+     * The package manager of the project
+     */
+    type?: string;
+    /**
+     * Whether the project is read-only
+     */
+    readOnly?: boolean;
+    /**
+     * The frequency of automated Snyk re-test. Can be 'daily', 'weekly or 'never'
+     */
+    testFrequency?: string;
+    /**
+     * Number of dependencies of the project
+     */
+    totalDependencies?: number;
+    /**
+     * Number of known vulnerabilities in the project, not including ignored issues
+     */
+    issueCountsBySeverity?: {
+        /**
+         * Number of low severity vulnerabilities
+         */
+        low?: number;
+        /**
+         * Number of medium severity vulnerabilities
+         */
+        medium?: number;
+        /**
+         * Number of high severity vulnerabilities
+         */
+        high?: number;
+        /**
+         * Number of critical severity vulnerabilities
+         */
+        critical?: number;
+    };
+    /**
+     * For docker projects shows the ID of the image
+     */
+    imageId?: string;
+    /**
+     * For docker projects shows the tag of the image
+     */
+    imageTag?: string;
+    /**
+     * For docker projects shows the base image
+     */
+    imageBaseImage?: string;
+    /**
+     * For docker projects shows the platform of the image
+     */
+    imagePlatform?: string;
+    /**
+     * For Kubernetes projects shows the origin cluster name
+     */
+    imageCluster?: string;
+    /**
+     * The hostname for a CLI project, null if not set
+     */
+    hostname?: string | null;
+    /**
+     * The project remote repository url. Only set for projects imported via the Snyk CLI tool.
+     */
+    remoteRepoUrl?: string;
+    /**
+     * The date on which the most recent test was conducted for this project
+     */
+    lastTestedDate?: string;
+    /**
+     * The user who owns the project, null if not set
+     *
+     * {
+     *     "id": "e713cf94-bb02-4ea0-89d9-613cce0caed2",
+     *     "name": "example-user@snyk.io",
+     *     "username": "exampleUser",
+     *     "email": "example-user@snyk.io"
+     * }
+     */
+    owner?: object | null;
+    /**
+     * URL with project overview
+     */
+    browseUrl?: string;
+    /**
+     * The user who imported the project
+     */
+    importingUser?: {
+        /**
+         * The ID of the user.
+         */
+        id?: string;
+        /**
+         * The name of the user.
+         */
+        name?: string;
+        /**
+         * The username of the user.
+         */
+        username?: string;
+        /**
+         * The email of the user.
+         */
+        email?: string;
+    };
+    /**
+     * Describes if a project is currently monitored or it is de-activated
+     */
+    isMonitored?: boolean;
+    /**
+     * The monitored branch (if available)
+     */
+    branch?: string | null;
+    /**
+     * The identifier for which revision of the resource is scanned by Snyk. For example this may be a branch for SCM project, or a tag for a container image
+     */
+    targetReference?: string | null;
+    /**
+     * List of applied tags
+     */
+    tags?: {
+        [key: string]: any;
+    }[];
+    /**
+     * Applied project attributes
+     */
+    attributes?: {
+        criticality?: {
+            [key: string]: any;
+        }[];
+        environment?: {
+            [key: string]: any;
+        }[];
+        lifecycle?: {
+            [key: string]: any;
+        }[];
+    };
+    /**
+     * Remediation data (if available)
+     */
+    remediation?: {
+        /**
+         * Recommended upgrades to apply to the project
+         *
+         * (object)
+         *     + upgradeTo (string, required) - `package@version` to upgrade to
+         *     + upgrades (array[string], required) -  List of `package@version` that will be upgraded as part of this upgrade
+         *     + vulns (array[string], required) - List of vulnerability ids that will be fixed as part of this upgrade
+         */
+        upgrade?: {
+            [key: string]: any;
+        };
+        /**
+         * Recommended patches to apply to the project
+         *
+         * (object)
+         *    paths (array) - List of paths to the vulnerable dependency that can be patched
+         */
+        patch?: {
+            [key: string]: any;
+        };
+        /**
+         * Recommended pins to apply to the project (Python only)
+         *
+         * (object)
+         *     + upgradeTo (string, required) - `package@version` to upgrade to
+         *     + vulns (array[string], required) - List of vulnerability ids that will be fixed as part of this upgrade
+         *     + isTransitive (boolean) - Describes if the dependency to be pinned is a transitive dependency
+         */
+        pin?: {
+            [key: string]: any;
+        };
+    };
+}

--- a/src/lib/snyk/snyk.ts
+++ b/src/lib/snyk/snyk.ts
@@ -4,11 +4,12 @@ import { convertIntoIssueWithPath } from '../utils/issuesUtils';
 import { requestsManager } from 'snyk-request-manager';
 import { IssuesPostResponseType } from '../types';
 
+const requestManager = new requestsManager({ userAgentPrefix: 'snyk-delta' });
+
 const getProject = async (
   orgID: string,
   projectID: string,
 ): Promise<snykClient.OrgTypes.ProjectGetResponseType> => {
-  const requestManager = new requestsManager({ userAgentPrefix: 'snyk-delta' });
   const url = `/org/${orgID}/project/${projectID}`;
   try {
     const projectData = await requestManager.request({
@@ -29,7 +30,6 @@ const getProject = async (
   }
 };
 async function getOrgUUID(orgSlug: string): Promise<string> {
-  const requestManager = new requestsManager({ userAgentPrefix: 'snyk-delta' });
   let orgUUID = '';
 
   let url = '/orgs';

--- a/src/lib/utils/issuesUtils.ts
+++ b/src/lib/utils/issuesUtils.ts
@@ -1,9 +1,8 @@
 import * as _ from 'lodash'
-import { getDebugModule } from './utils';
-import { AggregatedIssuesWithVulnPaths } from 'snyk-api-ts-client/dist/client/abstraction/org/aggregatedissues'; 
 import { IssuesPostResponseType } from '../types';
 import { getUpgradePath } from '../snyk/snyk';
 import { debug } from 'console';
+import { AggregatedIssuesWithVulnPaths } from '../snyk/aggregatedIssues';
 
 type Unpacked<T> = T extends (infer U)[]
   ? U

--- a/test/lib/index-inline-no-baseline.test.ts
+++ b/test/lib/index-inline-no-baseline.test.ts
@@ -51,10 +51,40 @@ describe('Test End 2 End - Inline mode - no baseline', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
             );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          default:
+        }
+      })
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-gomod.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/java-goof.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
+            );
           default:
         }
       });
-
     nock('https://snyk.io')
       .persist()
       .post(/.*/)

--- a/test/lib/index-inline-with-proj-coord-dep-changes.testskip.ts
+++ b/test/lib/index-inline-with-proj-coord-dep-changes.testskip.ts
@@ -52,6 +52,29 @@ describe('Test End 2 End - Inline mode with project coordinates', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
             );
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-poetry.json',
+            );
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/poetry-depgraph.json',
+            );
+          default:
+        }
+      })
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-poetry.json',
+            );
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-platform.json',
+            );
           default:
         }
       });

--- a/test/lib/index-inline-with-project-coordinates.test.ts
+++ b/test/lib/index-inline-with-project-coordinates.test.ts
@@ -53,6 +53,36 @@ describe('Test End 2 End - Inline mode with project coordinates', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
             );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          default:
+        }
+      })
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
+            );
           default:
         }
       });

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -58,35 +58,154 @@ describe('Test End 2 End - Inline mode', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/customerorgSlugToUUID.json',
             );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/java-goof-todolist-core-depgraph.json',
+            );
+          case '/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'dependencies/projectId-depgraph.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-1041788/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-1041788.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-584563/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-584563.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461017/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-C3P0-461017.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-174153/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-DOM4J-174153.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461018/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-C3P0-461018.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-31325/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-31325.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:c3p0:c3p0:LGPL-3.0/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-snyk:lic:maven:c3p0:c3p0:LGPL-3.0.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-2812975/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/vuln-path-SNYK-JAVA-DOM4J-2812975.json',
+            );
           default:
         }
-      });
-
-    nock('https://snyk.io')
-      .persist()
+      })
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln-one-license.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-gomod-aggregated.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/java-goof-todolist-core-aggregated-issues.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
             );
-          case '/api/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/aggregated-issues':
+          case '/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/projectId-aggregated-issues.json',
@@ -94,135 +213,169 @@ describe('Test End 2 End - Inline mode', () => {
 
           default:
         }
-      })
-      .get(/.*/)
-      .reply(200, (uri) => {
-        switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
-            return fs.readFileSync(
-              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
-            return fs.readFileSync(
-              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/dep-graph':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/java-goof-todolist-core-depgraph.json',
-            );
-          case '/api/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/dep-graph':
-            return fs.readFileSync(
-              fixturesFolderPath + 'dependencies/projectId-depgraph.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-1041788/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-1041788.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-584563/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-584563.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461017/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-C3P0-461017.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-174153/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-DOM4J-174153.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461018/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-C3P0-461018.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-31325/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-31325.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:c3p0:c3p0:LGPL-3.0/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-snyk:lic:maven:c3p0:c3p0:LGPL-3.0.json',
-            );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-2812975/paths?perPage=100&page=1':
-            return fs.readFileSync(
-              fixturesFolderPath +
-                'apiResponses/vuln-path-SNYK-JAVA-DOM4J-2812975.json',
-            );
-          default:
-        }
       });
+
+    // nock('https://snyk.io')
+    //   .persist()
+    //   .post(/.*/)
+    //   .reply(200, (uri) => {
+    //     switch (uri) {
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/test-goof-aggregated-one-vuln-one-license.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/aggregated-issues':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath + 'apiResponses/test-gomod-aggregated.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/aggregated-issues':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/java-goof-todolist-core-aggregated-issues.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
+    //         );
+    //       case '/api/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/aggregated-issues':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/projectId-aggregated-issues.json',
+    //         );
+
+    //       default:
+    //     }
+    //   })
+    //   .get(/.*/)
+    //   .reply(200, (uri) => {
+    //     switch (uri) {
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/dep-graph':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/dep-graph':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/java-goof-todolist-core-depgraph.json',
+    //         );
+    //       case '/api/v1/org/1234-1234-1234-1234-123456789012/project/37a29fe9-c342-4d70-8efc-df96a8d730b6/dep-graph':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath + 'dependencies/projectId-depgraph.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2436751.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-1041788/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-1041788.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGHIBERNATE-584563/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGHIBERNATE-584563.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2689634.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461017/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-C3P0-461017.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-174153/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-DOM4J-174153.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-C3P0-461018/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-C3P0-461018.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-31325/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-31325.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2823313.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2434828.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2330878.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-ORGSPRINGFRAMEWORK-2329097.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.javax.persistence:hibernate-jpa-2.1-api:EPL-1.0.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-entitymanager:LGPL-2.0.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-snyk:lic:maven:org.hibernate:hibernate-core:LGPL-2.0.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-snyk:lic:maven:org.hibernate.common:hibernate-commons-annotations:LGPL-2.1.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-snyk:lic:maven:org.aspectj:aspectjweaver:EPL-1.0.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/snyk:lic:maven:c3p0:c3p0:LGPL-3.0/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-snyk:lic:maven:c3p0:c3p0:LGPL-3.0.json',
+    //         );
+    //       case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/62b136c4-eaf7-46b1-ae76-ded54bc19a5a/issue/SNYK-JAVA-DOM4J-2812975/paths?perPage=100&page=1':
+    //         return fs.readFileSync(
+    //           fixturesFolderPath +
+    //             'apiResponses/vuln-path-SNYK-JAVA-DOM4J-2812975.json',
+    //         );
+    //       default:
+    //     }
+    //   });
   });
   it('Test Inline mode - no new issue', async () => {
     setTimeout(() => {

--- a/test/lib/index-module-no-baseline.test.ts
+++ b/test/lib/index-module-no-baseline.test.ts
@@ -51,6 +51,37 @@ describe('Test End 2 End - Inline mode', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
             );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          default:
+        }
+      })
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-goof.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/test-gomod.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/java-goof.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
+            );
           default:
         }
       });

--- a/test/lib/index-module.test.ts
+++ b/test/lib/index-module.test.ts
@@ -44,6 +44,41 @@ describe('Test End 2 End - Module', () => {
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
             );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
+            );
+          default:
+        }
+      })
+      .post(/.*/)
+      .reply(200, (uri) => {
+        switch (uri) {
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponses/test-goof-aggregated-one-vuln.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+            return fs.readFileSync(
+              fixturesFolderPath +
+                'apiResponsesForProjects/list-all-projects-org-playground.json',
+            );
           default:
         }
       });

--- a/test/lib/index-standalone.test.ts
+++ b/test/lib/index-standalone.test.ts
@@ -19,26 +19,26 @@ const mockedLog = (output: string): void => {
   consoleOutput.push(output);
 };
 beforeAll(() => {
-  nock('https://api.snyk.io')
-    .persist()
-    .get(/^(?!.*xyz).*$/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/projectsV3.json',
-          );
-        case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10&starting_after=v1.eyJpZCI6MzU2NTI5Mzd9':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/projectsV3-page2.json',
-          );
-        case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10&starting_after=v1.eyJpZCI6NjQyMjIxfQ%3D%3D':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
-          );
-        default:
-      }
-    });
+  // nock('https://api.snyk.io')
+  //   .persist()
+  //   .get(/^(?!.*xyz).*$/)
+  //   .reply(200, (uri) => {
+  //     switch (uri) {
+  //       case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10':
+  //         return fs.readFileSync(
+  //           fixturesFolderPath + 'apiResponses/projectsV3.json',
+  //         );
+  //       case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10&starting_after=v1.eyJpZCI6MzU2NTI5Mzd9':
+  //         return fs.readFileSync(
+  //           fixturesFolderPath + 'apiResponses/projectsV3-page2.json',
+  //         );
+  //       case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10&starting_after=v1.eyJpZCI6NjQyMjIxfQ%3D%3D':
+  //         return fs.readFileSync(
+  //           fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
+  //         );
+  //       default:
+  //     }
+  //   });
   console.log = mockedLog;
 });
 
@@ -57,17 +57,17 @@ afterEach(() => {
 
 describe('Test End 2 End - Standalone mode', () => {
   it('Test standalone mode - no new issue', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln.json',
@@ -80,20 +80,32 @@ describe('Test End 2 End - Standalone mode', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/projectsV3.json',
+            );
+          case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10&starting_after=v1.eyJpZCI6MzU2NTI5Mzd9':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/projectsV3-page2.json',
+            );
+          case '/rest/orgs/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects?version=2023-05-29&limit=10&starting_after=v1.eyJpZCI6NjQyMjIxfQ%3D%3D':
+            return fs.readFileSync(
+              fixturesFolderPath + 'apiResponses/projectsV3-page3.json',
+            );
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
@@ -129,17 +141,17 @@ describe('Test End 2 End - Standalone mode', () => {
   });
 
   it('Test standalone mode - 1 new issue', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-two-vuln-no-license.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln.json',
@@ -152,37 +164,37 @@ describe('Test End 2 End - Standalone mode', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
             console.log('uri good');
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
             console.log('uri good');
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
@@ -226,17 +238,17 @@ describe('Test End 2 End - Standalone mode', () => {
   });
 
   it('Test standalone mode - 1 new issue 1 new direct dep', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-two-vuln-no-license.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln.json',
@@ -249,36 +261,36 @@ describe('Test End 2 End - Standalone mode', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/goof-depgraph-from-api-with-one-more-direct-dep.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',
@@ -321,17 +333,17 @@ describe('Test End 2 End - Standalone mode', () => {
   });
 
   it('Test standalone mode - 1 new issue 1 new direct and 1 new indirect dep', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-two-vuln-no-license.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln.json',
@@ -344,36 +356,36 @@ describe('Test End 2 End - Standalone mode', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/goof-depgraph-from-api-with-one-more-direct-and-indirect-dep.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',

--- a/test/lib/snyk/issues.test.ts
+++ b/test/lib/snyk/issues.test.ts
@@ -718,12 +718,12 @@ describe('Test issues functions', () => {
   describe('Test convertIntoIssueWithPath', () => {
     it('Test convertIntoIssueWithPath - one issue (1 vuln, 0 license) - one path', async () => {
       // eslint-disable-next-line
-      nock('https://snyk.io')
+      nock('https://api.snyk.io')
         .persist()
         .get(/.*/)
         .reply(200, (uri) => {
           switch (uri) {
-            case '/api/v1/org/123/project/123/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
@@ -760,17 +760,17 @@ describe('Test issues functions', () => {
 
     it('Test convertIntoIssueWithPath - 3 issues (3 vuln, 0 license) - 3 paths', async () => {
       // eslint-disable-next-line
-      nock('https://snyk.io')
+      nock('https://api.snyk.io')
         .persist()
         .get(/.*/)
         .reply(200, (uri) => {
           switch (uri) {
-            case '/api/v1/org/123/project/123/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
               );
-            case '/api/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
@@ -813,22 +813,22 @@ describe('Test issues functions', () => {
 
     it('Test convertIntoIssueWithPath - 4 issues (3 vuln, 1 license) - 4 paths', async () => {
       // eslint-disable-next-line
-      nock('https://snyk.io')
+      nock('https://api.snyk.io')
         .persist()
         .get(/.*/)
         .reply(200, (uri) => {
           switch (uri) {
-            case '/api/v1/org/123/project/123/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
               );
-            case '/api/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
               );
-            case '/api/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
@@ -873,12 +873,12 @@ describe('Test issues functions', () => {
 
     it('Test convertIntoIssueWithPath - 1 issue (0 vuln, 1 license) ', async () => {
       // eslint-disable-next-line
-      nock('https://snyk.io')
+      nock('https://api.snyk.io')
         .persist()
         .get(/.*/)
         .reply(200, (uri) => {
           switch (uri) {
-            case '/api/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
@@ -915,17 +915,17 @@ describe('Test issues functions', () => {
 
     it('Test convertIntoIssueWithPath - test pagination ', async () => {
       // eslint-disable-next-line
-      nock('https://snyk.io')
+      nock('https://api.snyk.io')
         .persist()
         .get(/.*/)
         .reply(200, (uri) => {
           switch (uri) {
-            case '/api/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+            case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',
               );
-            case '/api/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
+            case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
               return fs.readFileSync(
                 fixturesFolderPath +
                   'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -97,36 +97,30 @@ beforeEach(() => {
           );
         case '/v1/org/123/project/123':
           return 'project';
-          break;
         case '/v1/org/123/project/123/dep-graph':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/depGraphGoof.json',
           );
-          break;
         case '/v1/org/123/project/123/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
           return fs.readFileSync(
             fixturesFolderPath +
               'apiResponses/SNYK-JS-PACRESOLVER-1564857-issue-paths.json',
           );
-          break;
         case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
           return fs.readFileSync(
             fixturesFolderPath +
               'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',
           );
-          break;
         case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
           return fs.readFileSync(
             fixturesFolderPath +
               'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
           );
-          break;
         case '/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
           return fs.readFileSync(
             fixturesFolderPath +
               'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
           );
-          break;
         default:
       }
     });

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -95,7 +95,38 @@ beforeEach(() => {
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/emptyorgSlugToUUID.json',
           );
-
+        case '/v1/org/123/project/123':
+          return 'project';
+          break;
+        case '/v1/org/123/project/123/dep-graph':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/depGraphGoof.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/SNYK-JS-PACRESOLVER-1564857-issue-paths.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
+          );
+          break;
         default:
       }
     });

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -121,6 +121,26 @@ beforeEach(() => {
             fixturesFolderPath +
               'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
           );
+        case '/v1/org/123/project/123/aggregated-issues':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/test-goof-aggregated-two-vuln-one-license.json',
+          );
+        default:
+      }
+    })
+    .post(/^(?!.*xyz).*$/)
+    .reply(200, (uri) => {
+      switch (uri) {
+        case '/v1/org/689ce7f9-7943-4a71-b704-2ba575f01089/projects':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/allProjects.json',
+          );
+        case '/v1/org/123/project/123/aggregated-issues':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/test-goof-aggregated-two-vuln-one-license.json',
+          );
         default:
       }
     });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Migrates helpers functions off the deprecated snyk ts client in favor of direct request via the snyk-request-manager with the better support for regional hostnames.

### Notes for the reviewer

Transparent change making the same calls directly instead of an additional library. Moved to api.snyk(.region).io pattern with /v1 or /rest depending on v1 vs REST endpoint.
