### PR TITLE
Fix/v1 vs rest api paths

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -24,6 +24,16 @@ ignore:
         reason: XSS Not applicable in such cli tool.
         expires: 2025-02-12T13:40:05.484Z
         created: 2025-01-13T13:40:05.491Z
+  SNYK-JS-AXIOS-9292519:
+    - '*':
+        reason: SSRF not applicable in cli tool
+        expires: 2025-05-11T13:59:23.536Z
+        created: 2025-04-11T13:59:23.538Z
+  SNYK-JS-AXIOS-9403194:
+    - '*':
+        reason: SSRF not applicable in cli tool
+        expires: 2025-05-11T13:59:35.869Z
+        created: 2025-04-11T13:59:35.872Z
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-LODASH-450202:

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -2,7 +2,7 @@
 import 'source-map-support/register';
 import * as snyk from './snyk/snyk';
 import handleError from './error';
-import {getPipedDataIn, init, getDebugModule} from './utils/utils';
+import { getPipedDataIn, init, getDebugModule } from './utils/utils';
 import * as issues from './snyk/issues';
 import * as dependencies from './snyk/dependencies';
 import * as isUUID from 'is-uuid';
@@ -15,6 +15,8 @@ import {
 import { displayOutput } from './snyk/displayOutput';
 import { computeFailCode } from './snyk/snyk_utils';
 export { SnykDeltaOutput } from './types';
+const Configstore = require('@snyk/configstore');
+
 const IS_JEST_TESTING = process.env.JEST_WORKER_ID !== undefined;
 
 const banner = `
@@ -31,6 +33,11 @@ const getDelta = async (
   setPassIfNoBaselineFlag = false,
   failOnOverride?: string,
 ): Promise<SnykDeltaOutput | number> => {
+  const configuredApi =
+    process.env.SNYK_API || new Configstore('snyk').get('endpoint');
+  if (!`${configuredApi}`.endsWith('/v1')) {
+    process.env.SNYK_API = `${configuredApi}/v1`;
+  }
 
   /* eslint-disable no-unsafe-finally */
 

--- a/src/lib/snyk/snyk_utils.ts
+++ b/src/lib/snyk/snyk_utils.ts
@@ -7,7 +7,7 @@ function getConfig(): { endpoint: string; token: string } {
   const snykApiEndpoint: string =
     process.env.SNYK_API ||
     new Configstore('snyk').get('endpoint') ||
-    'https://snyk.io/api/v1';
+    'https://api.snyk.io/v1';
   const snykToken =
     process.env.SNYK_TOKEN || new Configstore('snyk').get('api');
   return { endpoint: snykApiEndpoint, token: snykToken };

--- a/test/lib/index-inline-no-baseline.test.ts
+++ b/test/lib/index-inline-no-baseline.test.ts
@@ -9,6 +9,12 @@ const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 process.argv.push('--setPassIfNoBaseline true');
 
 describe('Test End 2 End - Inline mode - no baseline', () => {
+  beforeAll(() => {
+    process.env.SNYK_API = 'https://api.snyk.io/v1';
+  });
+  afterAll(() => {
+    delete process.env.SNYK_API;
+  });
   const stdinMock: MockSTDIN = stdin();
   const mockExit = mockProcessExit();
   const originalLog = console.log;
@@ -85,28 +91,28 @@ describe('Test End 2 End - Inline mode - no baseline', () => {
           default:
         }
       });
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-gomod.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/java-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',

--- a/test/lib/index-inline-with-proj-coord-dep-changes.testskip.ts
+++ b/test/lib/index-inline-with-proj-coord-dep-changes.testskip.ts
@@ -78,16 +78,16 @@ describe('Test End 2 End - Inline mode with project coordinates', () => {
           default:
         }
       });
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-poetry.json',
             );
-          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/projects':
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/projects':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponsesForProjects/list-all-projects-platform.json',
@@ -98,11 +98,11 @@ describe('Test End 2 End - Inline mode with project coordinates', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-poetry.json',
             );
-          case '/api/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/dep-graph':
+          case '/v1/org/f6999a85-c519-4ee7-ae55-3269b9bfa4b6/project/f51c925b-2abe-4c07-8a0d-21b834aa3074/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/poetry-depgraph.json',
             );

--- a/test/lib/index-inline-with-project-coordinates.test.ts
+++ b/test/lib/index-inline-with-project-coordinates.test.ts
@@ -13,6 +13,12 @@ import { getDelta } from '../../src/lib/index';
 
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 describe('Test End 2 End - Inline mode with project coordinates', () => {
+  beforeAll(() => {
+    process.env.SNYK_API = 'https://api.snyk.io/v1';
+  });
+  afterAll(() => {
+    delete process.env.SNYK_API;
+  });
   const originalLog = console.log;
   let consoleOutput: Array<string> = [];
   const mockedLog = (output: string): void => {
@@ -86,22 +92,22 @@ describe('Test End 2 End - Inline mode with project coordinates', () => {
           default:
         }
       });
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/aggregated-issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-aggregated-one-vuln.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
@@ -112,12 +118,12 @@ describe('Test End 2 End - Inline mode with project coordinates', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -11,6 +11,12 @@ import { getDelta } from '../../src/lib/index';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
 describe('Test End 2 End - Inline mode', () => {
+  beforeAll(() => {
+    process.env.SNYK_API = 'https://api.snyk.io/v1';
+  });
+  afterAll(() => {
+    delete process.env.SNYK_API;
+  });
   const originalLog = console.log;
 
   let consoleOutput: Array<string> = [];

--- a/test/lib/index-module-no-baseline.test.ts
+++ b/test/lib/index-module-no-baseline.test.ts
@@ -11,6 +11,12 @@ import { getDelta } from '../../src/lib/index';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
 describe('Test End 2 End - Inline mode', () => {
+  beforeAll(() => {
+    process.env.SNYK_API = 'https://api.snyk.io/v1';
+  });
+  afterAll(() => {
+    delete process.env.SNYK_API;
+  });
   const originalLog = console.log;
   let consoleOutput: Array<string> = [];
   const mockedLog = (output: string): void => {
@@ -86,28 +92,28 @@ describe('Test End 2 End - Inline mode', () => {
         }
       });
 
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/09235fa4-c241-42c6-8c63-c053bd272786/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-gomod.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/37a29fe9-c342-4d70-8efc-df96a8d730b3/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/java-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/projects':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponsesForProjects/list-all-projects-org-361fd3c0-41d4-4ea4-ba77-09bb17890967.json',
@@ -118,7 +124,7 @@ describe('Test End 2 End - Inline mode', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );

--- a/test/lib/index-module.test.ts
+++ b/test/lib/index-module.test.ts
@@ -6,6 +6,12 @@ import debug from 'debug';
 import { getDelta } from '../../src/lib/index';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 describe('Test End 2 End - Module', () => {
+  beforeAll(() => {
+    process.env.SNYK_API = 'https://api.snyk.io/v1';
+  });
+  afterAll(() => {
+    delete process.env.SNYK_API;
+  });
   const originalLog = console.log;
   let consoleOutput: Array<string> = [];
   const mockedLog = (output: string): void => {
@@ -83,7 +89,7 @@ describe('Test End 2 End - Module', () => {
         }
       });
 
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
@@ -110,16 +116,16 @@ describe('Test End 2 End - Module', () => {
       .reply(200, (uri) => {
         console.log(uri);
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-ACORN-559469/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-ACORN-559469-issue-paths.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/ab9e037f-9020-4f77-9c48-b1cb0295a4b6/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',

--- a/test/lib/index-standalone-no-baseline.ts
+++ b/test/lib/index-standalone-no-baseline.ts
@@ -57,16 +57,16 @@ afterEach(() => {
 
 describe('Test End 2 End - Standalone mode without baseline', () => {
   it('Test standalone mode - no new issue', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
@@ -78,11 +78,11 @@ describe('Test End 2 End - Standalone mode without baseline', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
@@ -117,16 +117,16 @@ describe('Test End 2 End - Standalone mode without baseline', () => {
   });
 
   it('Test standalone mode - 1 new issue', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-with-one-more-vuln.json',
@@ -139,11 +139,11 @@ describe('Test End 2 End - Standalone mode without baseline', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
@@ -183,16 +183,16 @@ describe('Test End 2 End - Standalone mode without baseline', () => {
   });
 
   it('Test standalone mode - 1 new issue 1 new direct dep', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-with-one-more-vuln.json',
@@ -205,12 +205,12 @@ describe('Test End 2 End - Standalone mode without baseline', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/goof-depgraph-from-api-with-one-more-direct-dep.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );
@@ -249,16 +249,16 @@ describe('Test End 2 End - Standalone mode without baseline', () => {
   });
 
   it('Test standalone mode - 1 new issue 1 new direct and 1 new indirect dep', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .persist()
       .post(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/issues':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/test-goof.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/issues':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/test-goof-with-one-more-vuln.json',
@@ -271,12 +271,12 @@ describe('Test End 2 End - Standalone mode without baseline', () => {
       .get(/.*/)
       .reply(200, (uri) => {
         switch (uri) {
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a73/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath +
                 'apiResponses/goof-depgraph-from-api-with-one-more-direct-and-indirect-dep.json',
             );
-          case '/api/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
+          case '/v1/org/361fd3c0-41d4-4ea4-ba77-09bb17890967/project/c51c80c2-66a1-442a-91e2-4f55b4256a72/dep-graph':
             return fs.readFileSync(
               fixturesFolderPath + 'apiResponses/goof-depgraph-from-api.json',
             );

--- a/test/lib/index-standalone.test.ts
+++ b/test/lib/index-standalone.test.ts
@@ -41,6 +41,12 @@ beforeAll(() => {
   //   });
   console.log = mockedLog;
 });
+beforeAll(() => {
+  process.env.SNYK_API = 'https://api.snyk.io/v1';
+});
+afterAll(() => {
+  delete process.env.SNYK_API;
+});
 
 beforeEach(() => {
   consoleOutput = [];

--- a/test/lib/snyk/issues.test.ts
+++ b/test/lib/snyk/issues.test.ts
@@ -716,6 +716,13 @@ describe('Test issues functions', () => {
   });
 
   describe('Test convertIntoIssueWithPath', () => {
+    beforeAll(() => {
+      process.env.SNYK_API = 'https://api.snyk.io/v1';
+    });
+    afterAll(() => {
+      delete process.env.SNYK_API;
+    });
+
     it('Test convertIntoIssueWithPath - one issue (1 vuln, 0 license) - one path', async () => {
       // eslint-disable-next-line
       nock('https://api.snyk.io')

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -13,63 +13,6 @@ import * as Error from '../../../src/lib/customErrors/apiError';
 
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
 beforeEach(() => {
-  nock('https://snyk.io')
-    .persist()
-    .post(/^(?!.*xyz).*$/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/689ce7f9-7943-4a71-b704-2ba575f01089/projects':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/allProjects.json',
-          );
-        case '/api/v1/org/123/project/123/aggregated-issues':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/test-goof-aggregated-two-vuln-one-license.json',
-          );
-        default:
-      }
-    })
-    .get(/^(?!.*xyz).*$/)
-    .reply(200, (uri) => {
-      switch (uri) {
-        case '/api/v1/org/123/project/123':
-          return 'project';
-          break;
-        case '/api/v1/org/123/project/123/dep-graph':
-          return fs.readFileSync(
-            fixturesFolderPath + 'apiResponses/depGraphGoof.json',
-          );
-          break;
-        case '/api/v1/org/123/project/123/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/SNYK-JS-PACRESOLVER-1564857-issue-paths.json',
-          );
-          break;
-        case '/api/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',
-          );
-          break;
-        case '/api/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
-          );
-          break;
-        case '/api/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
-          return fs.readFileSync(
-            fixturesFolderPath +
-              'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
-          );
-          break;
-
-        default:
-      }
-    });
-
   nock('https://api.snyk.io')
     .persist()
     .get(/^(?!.*xyz).*$/)
@@ -126,6 +69,38 @@ beforeEach(() => {
             fixturesFolderPath +
               'apiResponses/test-goof-aggregated-two-vuln-one-license.json',
           );
+        case '/v1/org/123/project/123':
+          return 'project';
+          break;
+        case '/v1/org/123/project/123/dep-graph':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/depGraphGoof.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/SNYK-JS-PACRESOLVER-1564857/paths?perPage=100&page=1':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/SNYK-JS-PACRESOLVER-1564857-issue-paths.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=1':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page2.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/SNYK-JS-DOTPROP-543489/paths?perPage=100&page=2':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/SNYK-JS-DOTPROP-543489-issue-paths-page1.json',
+          );
+          break;
+        case '/v1/org/123/project/123/issue/snyk:lic:npm:goof:GPL-2.0/paths?perPage=100&page=1':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/snyk-lic-npm-goof-GPL-2-0-issue-paths.json',
+          );
+          break;
         default:
       }
     })
@@ -141,12 +116,27 @@ beforeEach(() => {
             fixturesFolderPath +
               'apiResponses/test-goof-aggregated-two-vuln-one-license.json',
           );
+        case '/v1/org/689ce7f9-7943-4a71-b704-2ba575f01089/projects':
+          return fs.readFileSync(
+            fixturesFolderPath + 'apiResponses/allProjects.json',
+          );
+        case '/v1/org/123/project/123/aggregated-issues':
+          return fs.readFileSync(
+            fixturesFolderPath +
+              'apiResponses/test-goof-aggregated-two-vuln-one-license.json',
+          );
         default:
       }
     });
 });
 
 describe('Test endpoint functions', () => {
+  beforeAll(() => {
+    process.env.SNYK_API = 'https://api.snyk.io/v1';
+  });
+  afterAll(() => {
+    delete process.env.SNYK_API;
+  });
   it('Test GetProject', async () => {
     const project = await getProject('123', '123');
     expect(project).toEqual('project');

--- a/test/lib/snyk/snyk_utils.test.ts
+++ b/test/lib/snyk/snyk_utils.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
 beforeEach(() => {
-  return nock('https://snyk.io')
+  return nock('https://api.snyk.io')
     .get(/\/xyz/)
     .reply(404, '404')
     .post(/\/xyz/)
@@ -25,7 +25,7 @@ beforeEach(() => {
     .post(/^(?!.*xyz).*$/)
     .reply(200, (uri, requestBody) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return requestBody;
           break;
         default:
@@ -34,7 +34,7 @@ beforeEach(() => {
     .get(/^(?!.*xyz).*$/)
     .reply(200, (uri) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/general-doc.json',
           );
@@ -61,7 +61,7 @@ describe('Test getConfig function', () => {
   });
 
   it('Get snyk.io api endpoint default', async () => {
-    expect(getConfig().endpoint).toEqual('https://snyk.io/api/v1');
+    expect(getConfig().endpoint).toEqual('https://api.snyk.io/v1');
   });
 
   it('Get snyk api endpoint via env var', async () => {


### PR DESCRIPTION
- [] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Aligns the v1 path to the default expect api value irrespective of the configuration method.

### Notes for the reviewer

The underlying snyk-request-manager defaults to v1 if not specified, expecting otherwise a v1 path. While the fix probably would make sense in the snyk-request-manager, changing the behavior would likely be a breaking change. Instead, snyk-delta will ensure the correctly suffix if not already there.