### PR TITLE
Fix v1 endpoint check

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -33,12 +33,6 @@ const getDelta = async (
   setPassIfNoBaselineFlag = false,
   failOnOverride?: string,
 ): Promise<SnykDeltaOutput | number> => {
-  const configuredApi =
-    process.env.SNYK_API || new Configstore('snyk').get('endpoint');
-  if (!`${configuredApi}`.endsWith('/v1')) {
-    process.env.SNYK_API = `${configuredApi}/v1`;
-  }
-
   /* eslint-disable no-unsafe-finally */
 
   if (process.env.NODE_ENV == 'prod') {

--- a/src/lib/snyk/snyk_utils.ts
+++ b/src/lib/snyk/snyk_utils.ts
@@ -4,10 +4,13 @@ import { getDebugModule } from '../utils/utils';
 const Configstore = require('@snyk/configstore');
 
 function getConfig(): { endpoint: string; token: string } {
-  const snykApiEndpoint: string =
+  let snykApiEndpoint: string =
     process.env.SNYK_API ||
     new Configstore('snyk').get('endpoint') ||
-    'https://api.snyk.io/v1';
+    'https://api.snyk.io';
+  if (!`${snykApiEndpoint}`.endsWith('/v1')) {
+    snykApiEndpoint = `${snykApiEndpoint}/v1`;
+  }
   const snykToken =
     process.env.SNYK_TOKEN || new Configstore('snyk').get('api');
   return { endpoint: snykApiEndpoint, token: snykToken };

--- a/test/lib/index-inline-no-baseline.test.ts
+++ b/test/lib/index-inline-no-baseline.test.ts
@@ -9,12 +9,6 @@ const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 process.argv.push('--setPassIfNoBaseline true');
 
 describe('Test End 2 End - Inline mode - no baseline', () => {
-  beforeAll(() => {
-    process.env.SNYK_API = 'https://api.snyk.io/v1';
-  });
-  afterAll(() => {
-    delete process.env.SNYK_API;
-  });
   const stdinMock: MockSTDIN = stdin();
   const mockExit = mockProcessExit();
   const originalLog = console.log;

--- a/test/lib/index-inline-with-project-coordinates.test.ts
+++ b/test/lib/index-inline-with-project-coordinates.test.ts
@@ -13,12 +13,6 @@ import { getDelta } from '../../src/lib/index';
 
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 describe('Test End 2 End - Inline mode with project coordinates', () => {
-  beforeAll(() => {
-    process.env.SNYK_API = 'https://api.snyk.io/v1';
-  });
-  afterAll(() => {
-    delete process.env.SNYK_API;
-  });
   const originalLog = console.log;
   let consoleOutput: Array<string> = [];
   const mockedLog = (output: string): void => {

--- a/test/lib/index-inline.test.ts
+++ b/test/lib/index-inline.test.ts
@@ -11,12 +11,6 @@ import { getDelta } from '../../src/lib/index';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
 describe('Test End 2 End - Inline mode', () => {
-  beforeAll(() => {
-    process.env.SNYK_API = 'https://api.snyk.io/v1';
-  });
-  afterAll(() => {
-    delete process.env.SNYK_API;
-  });
   const originalLog = console.log;
 
   let consoleOutput: Array<string> = [];

--- a/test/lib/index-module-no-baseline.test.ts
+++ b/test/lib/index-module-no-baseline.test.ts
@@ -11,12 +11,6 @@ import { getDelta } from '../../src/lib/index';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 
 describe('Test End 2 End - Inline mode', () => {
-  beforeAll(() => {
-    process.env.SNYK_API = 'https://api.snyk.io/v1';
-  });
-  afterAll(() => {
-    delete process.env.SNYK_API;
-  });
   const originalLog = console.log;
   let consoleOutput: Array<string> = [];
   const mockedLog = (output: string): void => {

--- a/test/lib/index-module.test.ts
+++ b/test/lib/index-module.test.ts
@@ -6,12 +6,6 @@ import debug from 'debug';
 import { getDelta } from '../../src/lib/index';
 const fixturesFolderPath = path.resolve(__dirname, '..') + '/fixtures/';
 describe('Test End 2 End - Module', () => {
-  beforeAll(() => {
-    process.env.SNYK_API = 'https://api.snyk.io/v1';
-  });
-  afterAll(() => {
-    delete process.env.SNYK_API;
-  });
   const originalLog = console.log;
   let consoleOutput: Array<string> = [];
   const mockedLog = (output: string): void => {

--- a/test/lib/index-standalone.test.ts
+++ b/test/lib/index-standalone.test.ts
@@ -41,13 +41,6 @@ beforeAll(() => {
   //   });
   console.log = mockedLog;
 });
-beforeAll(() => {
-  process.env.SNYK_API = 'https://api.snyk.io/v1';
-});
-afterAll(() => {
-  delete process.env.SNYK_API;
-});
-
 beforeEach(() => {
   consoleOutput = [];
 });

--- a/test/lib/snyk/issues.test.ts
+++ b/test/lib/snyk/issues.test.ts
@@ -716,13 +716,6 @@ describe('Test issues functions', () => {
   });
 
   describe('Test convertIntoIssueWithPath', () => {
-    beforeAll(() => {
-      process.env.SNYK_API = 'https://api.snyk.io/v1';
-    });
-    afterAll(() => {
-      delete process.env.SNYK_API;
-    });
-
     it('Test convertIntoIssueWithPath - one issue (1 vuln, 0 license) - one path', async () => {
       // eslint-disable-next-line
       nock('https://api.snyk.io')

--- a/test/lib/snyk/snyk.test.ts
+++ b/test/lib/snyk/snyk.test.ts
@@ -131,12 +131,6 @@ beforeEach(() => {
 });
 
 describe('Test endpoint functions', () => {
-  beforeAll(() => {
-    process.env.SNYK_API = 'https://api.snyk.io/v1';
-  });
-  afterAll(() => {
-    delete process.env.SNYK_API;
-  });
   it('Test GetProject', async () => {
     const project = await getProject('123', '123');
     expect(project).toEqual('project');

--- a/test/lib/snyk/snyk_utils.test.ts
+++ b/test/lib/snyk/snyk_utils.test.ts
@@ -68,4 +68,9 @@ describe('Test getConfig function', () => {
     process.env.SNYK_API = 'API';
     expect(getConfig().endpoint).toEqual('API');
   });
+
+  it('Get snyk api endpoint via env var', async () => {
+    process.env.SNYK_API = 'https://api.snyk.io/';
+    expect(getConfig().endpoint).toEqual('https://api.snyk.io/v1');
+  });
 });

--- a/test/lib/snyk/snyk_utils.test.ts
+++ b/test/lib/snyk/snyk_utils.test.ts
@@ -66,10 +66,10 @@ describe('Test getConfig function', () => {
 
   it('Get snyk api endpoint via env var', async () => {
     process.env.SNYK_API = 'API';
-    expect(getConfig().endpoint).toEqual('API');
+    expect(getConfig().endpoint).toEqual('API/v1');
   });
 
-  it('Get snyk api endpoint via env var', async () => {
+  it('Check snyk api endpoint is /v1', async () => {
     process.env.SNYK_API = 'https://api.snyk.io/';
     expect(getConfig().endpoint).toEqual('https://api.snyk.io/v1');
   });

--- a/test/lib/snyk/snyk_utils.test.ts
+++ b/test/lib/snyk/snyk_utils.test.ts
@@ -70,7 +70,7 @@ describe('Test getConfig function', () => {
   });
 
   it('Check snyk api endpoint is /v1', async () => {
-    process.env.SNYK_API = 'https://api.snyk.io/';
+    process.env.SNYK_API = 'https://api.snyk.io';
     expect(getConfig().endpoint).toEqual('https://api.snyk.io/v1');
   });
 });


### PR DESCRIPTION
- Check must be done only if there is a configured endpoint- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

I think there is a bug in [this change](https://github.com/snyk-tech-services/snyk-delta/commit/1088fc0ad7ff2872c98c99f52560969f663ac70c) that was released in v1.12.6. If there is no endpoint configuration set, it would use `undefined/v1` as the endpoint. The check must happen only if a configuration exists. The actual check could even be made more robust, but I don't have enough context regarding the motivation of the initial change.

### Notes for the reviewer

_Instructions on how to run this locally, background context, what to review, questions…_

### More information

- [Jira ticket SC-0000](https://snyksec.atlassian.net/browse/SC-0000)
- [Link to documentation](https://github.com/snyk/snyk-delta/wiki/)

### Screenshots

_Visuals that may help the reviewer_
