### PR TITLE
fix: add default api value

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -34,7 +34,7 @@ const getDelta = async (
   failOnOverride?: string,
 ): Promise<SnykDeltaOutput | number> => {
   const configuredApi =
-    process.env.SNYK_API || new Configstore('snyk').get('endpoint');
+    process.env.SNYK_API || new Configstore('snyk').get('endpoint') || 'https://api.snyk.io';
   if (!`${configuredApi}`.endsWith('/v1')) {
     process.env.SNYK_API = `${configuredApi}/v1`;
   }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds default api value if nothing else is set.

### Notes for the reviewer

The intent of setting the SNYK_API env var early is to also configure the right api endpoint for the underlying snyk-request-manager library in a way that is compatible for all regions across v1 and REST endpoints.